### PR TITLE
Add `trimja::ninja_clock`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(
     src/trimja.m.cpp
     src/depsreader.cpp
     src/graph.cpp
+    src/ninja_clock.cpp
     src/trimutil.cpp
     thirdparty/ninja/lexer.cc
     $<$<BOOL:${WIN32}>:thirdparty/ninja/getopt.c>
@@ -92,6 +93,7 @@ add_executable(
     src/depsreader.cpp
     src/depswriter.cpp
     src/graph.cpp
+    src/ninja_clock.cpp
     src/trimutil.cpp
     thirdparty/ninja/lexer.cc
     $<$<BOOL:${WIN32}>:thirdparty/ninja/getopt.c>

--- a/src/ninja_clock.cpp
+++ b/src/ninja_clock.cpp
@@ -1,0 +1,59 @@
+// MIT License
+//
+// Copyright (c) 2024 Elliot Goodrich
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "ninja_clock.h"
+
+namespace std {
+namespace chrono {
+
+#if defined(_MSC_VER)
+
+namespace {
+
+// The `file_clock::time_point` in Visual Studio is the same as the `FILETIME`
+// struct.
+// https://learn.microsoft.com/en-us/cpp/standard-library/file-clock-class
+
+// ninja subtracts the number below to shift the epoch from 1601 to 2001
+const std::uint64_t offset = 126'227'704'000'000'000;
+
+}  // namespace
+
+trimja::ninja_clock::time_point
+clock_time_conversion<trimja::ninja_clock, file_clock>::operator()(
+    file_clock::time_point t) {
+  return trimja::ninja_clock::time_point(
+      trimja::ninja_clock::duration(t.time_since_epoch().count() - offset));
+};
+
+file_clock::time_point
+clock_time_conversion<file_clock, trimja::ninja_clock>::operator()(
+    trimja::ninja_clock::time_point t) {
+  return file_clock::time_point(
+      file_clock::duration(t.time_since_epoch().count() + offset));
+}
+#else
+#error "TODO"
+#endif
+
+}  // namespace chrono
+}  // namespace std

--- a/src/ninja_clock.h
+++ b/src/ninja_clock.h
@@ -1,0 +1,54 @@
+// MIT License
+//
+// Copyright (c) 2024 Elliot Goodrich
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <chrono>
+
+namespace trimja {
+
+// `ninja_clock` represents the on-disk time saved within the `.ninja_deps`
+// file.  `ninja_clock::time_point` is guaranteed to be the same layout
+// as the last modified time saved in this file.
+struct ninja_clock {
+  using rep = std::uint64_t;
+  using period = std::nano;
+  using duration = std::chrono::duration<rep, period>;
+  using time_point = std::chrono::time_point<ninja_clock>;
+  static const bool is_steady = false;
+};
+
+}  // namespace trimja
+
+namespace std {
+namespace chrono {
+
+template <>
+struct clock_time_conversion<trimja::ninja_clock, file_clock> {
+  trimja::ninja_clock::time_point operator()(file_clock::time_point t);
+};
+
+template <>
+struct clock_time_conversion<file_clock, trimja::ninja_clock> {
+  file_clock::time_point operator()(trimja::ninja_clock::time_point t);
+};
+
+}  // namespace chrono
+}  // namespace std


### PR DESCRIPTION
Create a `std::chrono` clock that can represent the modification times stored within `.ninja_deps`.  I realised that on little-endian machines we can read/write a `std::uint64_t` directly, which simplifies things enormously.

Now that we have our own `ninja_clock::time_point`, we can specialize `std::chrono::clock_time_conversion` to convert between this and `file_clock`.  This allows the reader/writer code to not know about this conversion and instead put it in a single place outside this code.

As ninja has platform specific code when writing `.ninja_deps` we will have to have the same and this is more easily done in `ninja_clock.cpp`.