### PR TITLE
Fix `--output` location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,25 @@ add_test(
     COMMAND trimja --write --restrict changed.txt
 )
 
+# Check we can write to a different file
+add_test(
+    NAME trimja.--write
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests/trimja/passthrough/
+    COMMAND trimja --output ${CMAKE_CURRENT_BINARY_DIR}/trimja.ninja --restrict changed.txt
+)
+add_test(
+    NAME trimja.--write.cmp
+    COMMAND ${CMAKE_COMMAND} -E compare_files ${CMAKE_CURRENT_SOURCE_DIR}/tests/trimja/passthrough/build.ninja ${CMAKE_CURRENT_BINARY_DIR}/trimja.ninja
+)
+set_tests_properties(
+    trimja.--write.cmp
+    PROPERTIES FIXTURES_REQUIRED trimja.--write.fixture
+)
+set_tests_properties(
+    trimja.--write
+    PROPERTIES FIXTURES_SETUP trimja.--write.fixture
+)
+
 # Check redirection from a file
 if (WIN32)
     add_test(

--- a/src/trimja.m.cpp
+++ b/src/trimja.m.cpp
@@ -204,7 +204,7 @@ int main(int argc, char** argv) try {
                    return outStream.emplace<std::stringstream>();
                  },
                  [&](const std::filesystem::path& out) -> std::ostream& {
-                   return outStream.emplace<std::ofstream>(ninjaFile);
+                   return outStream.emplace<std::ofstream>(out);
                  }},
       outputFile);
 


### PR DESCRIPTION
`--output` was always saving to the input ninja file instead of where you specified it.