### PR TITLE
Improve `default` semantics

### DIFF
--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -34,14 +34,18 @@ std::size_t Graph::addPath(const std::string& path) {
   if (inserted) {
     m_inputToOutput.emplace_back();
     m_outputToInput.emplace_back();
+    m_path.push_back(path);
   }
   return it->second;
 }
 
 std::size_t Graph::addDefault() {
+  assert(m_defaultIndex == -1);
   const std::size_t nextIndex = m_inputToOutput.size();
   m_inputToOutput.emplace_back();
   m_outputToInput.emplace_back();
+  m_path.push_back("default");
+  m_defaultIndex = nextIndex;
   return nextIndex;
 }
 
@@ -49,6 +53,14 @@ void Graph::addEdge(std::size_t in, std::size_t out) {
   assert(in != out);
   m_inputToOutput[in].insert(out);
   m_outputToInput[out].insert(in);
+}
+
+bool Graph::isDefault(std::size_t pathIndex) const {
+  return pathIndex == m_defaultIndex;
+}
+
+std::string_view Graph::path(std::size_t pathIndex) const {
+  return m_path[pathIndex];
 }
 
 const std::set<std::size_t>& Graph::out(std::size_t pathIndex) const {

--- a/src/graph.h
+++ b/src/graph.h
@@ -41,6 +41,11 @@ class Graph {
   // An adjacency list of output -> Input
   std::vector<std::set<std::size_t>> m_outputToInput;
 
+  // names of paths
+  std::vector<std::string> m_path;
+
+  std::size_t m_defaultIndex = -1;
+
  public:
   Graph();
 
@@ -50,6 +55,9 @@ class Graph {
 
   void addEdge(std::size_t in, std::size_t out);
 
+  bool isDefault(std::size_t pathIndex) const;
+
+  std::string_view path(std::size_t pathIndex) const;
   const std::set<std::size_t>& out(std::size_t pathIndex) const;
   const std::set<std::size_t>& in(std::size_t pathIndex) const;
 

--- a/tests/trimja/default/build.ninja
+++ b/tests/trimja/default/build.ninja
@@ -1,4 +1,7 @@
-build a_out: phony a_in
-build b_out: phony b_in
-build c_out: phony c_in
-default a_out b_out c_out
+build intermediate_a0: touch a_in
+build intermediate_a1: touch a_in
+build a_out: fiddle intermediate_a0 intermediate_a0
+build intermediate_b: touch b_in
+build b_out: fiddle intermediate_b
+default a_out b_out c_out d_in
+build c_out: touch c_in

--- a/tests/trimja/default/expected.ninja
+++ b/tests/trimja/default/expected.ninja
@@ -1,4 +1,6 @@
-build a_out: phony a_in
-build b_out: phony b_in
-build c_out: phony c_in
-default a_out b_out c_out
+build intermediate_a0: touch a_in
+build intermediate_a1: touch a_in
+build a_out: fiddle intermediate_a0 intermediate_a0
+build b_out: phony
+default a_out b_out c_out d_in
+build c_out: touch c_in


### PR DESCRIPTION
For all paths specified in `default` that are not required by anything else we don't really want to build them when running `ninja` without any targets.

Instead of splitting up the `default` statement into different parts and printing out only the required parts, we keep the `default` statement identical and instead create empty `phony` build commands for output statements that are not required but are mentioned.