### PR TITLE
Fix missing `default`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,7 +98,7 @@ endif()
 set_property(TEST trimja.stdin PROPERTY PASS_REGULAR_EXPRESSION "build out1")
 
 # Snapshot tests
-foreach(TEST default passthrough simple simple_reversed chained fan pyramid dependencies attached basic_dyndep)
+foreach(TEST default default_unused passthrough simple simple_reversed chained fan pyramid dependencies attached basic_dyndep)
     add_test(
         NAME trimja.snapshot.${TEST}
         COMMAND trimja

--- a/src/trimutil.cpp
+++ b/src/trimutil.cpp
@@ -448,7 +448,13 @@ void TrimUtil::trim(std::ostream& output,
   // Mark all inputs as required or not
   for (std::size_t index = 0; index < graph.size(); ++index) {
     if (graph.isDefault(index)) {
+      // Mark the default node as anything other than `Unknown` so it
+      // always gets printed
+      requirements[index] = Requirement::Inputs;
       for (const std::size_t in : graph.in(index)) {
+        // Mark all `Unknown` direct inputs to create phony build commands
+        // since we only want to build those inputs to `default` that
+        // are required
         switch (requirements[in]) {
           case Requirement::Unknown:
             requirements[in] = Requirement::CreatePhony;

--- a/tests/trimja/default_unused/build.ninja
+++ b/tests/trimja/default_unused/build.ninja
@@ -1,0 +1,1 @@
+default in

--- a/tests/trimja/default_unused/expected.ninja
+++ b/tests/trimja/default_unused/expected.ninja
@@ -1,0 +1,1 @@
+default in


### PR DESCRIPTION
When we have a `default` that has no inputs that have been marked as required, we stil need to output it. Otherwise `ninja` will build everything in the build file when running without a target instead of what was specified in `default`.