### PR TITLE
Include all build outputs in trimmed file

### DIFF
--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -59,6 +59,10 @@ bool Graph::isDefault(std::size_t pathIndex) const {
   return pathIndex == m_defaultIndex;
 }
 
+std::size_t Graph::defaultIndex() const {
+  return m_defaultIndex;
+}
+
 std::string_view Graph::path(std::size_t pathIndex) const {
   return m_path[pathIndex];
 }

--- a/src/graph.h
+++ b/src/graph.h
@@ -56,6 +56,7 @@ class Graph {
   void addEdge(std::size_t in, std::size_t out);
 
   bool isDefault(std::size_t pathIndex) const;
+  std::size_t defaultIndex() const;
 
   std::string_view path(std::size_t pathIndex) const;
   const std::set<std::size_t>& out(std::size_t pathIndex) const;

--- a/tests/trimja/attached/expected.ninja
+++ b/tests/trimja/attached/expected.ninja
@@ -1,4 +1,6 @@
+build ignored: phony
 build a: copy b
 build out: concat changed a c
 build c: copy d
 build out2: copy out
+build ignored2: phony

--- a/tests/trimja/basic_dyndep/expected.ninja
+++ b/tests/trimja/basic_dyndep/expected.ninja
@@ -2,4 +2,5 @@ rule copy
   command = cp $in $out
   deps = msvc
   description = Copying $out
+build out.txt: phony
 build out2.txt: cp in.txt

--- a/tests/trimja/chained/expected.ninja
+++ b/tests/trimja/chained/expected.ninja
@@ -3,3 +3,8 @@ build b: copy c
 build c: copy d
 build d: copy e
 build e: copy f
+build z: phony
+build y: phony
+build x: phony
+build w: phony
+build v: phony

--- a/tests/trimja/default/expected.ninja
+++ b/tests/trimja/default/expected.ninja
@@ -1,6 +1,7 @@
 build intermediate_a0: touch a_in
 build intermediate_a1: touch a_in
 build a_out: fiddle intermediate_a0 intermediate_a0
+build intermediate_b: phony
 build b_out: phony
 default a_out b_out c_out d_in
 build c_out: touch c_in

--- a/tests/trimja/fan/expected.ninja
+++ b/tests/trimja/fan/expected.ninja
@@ -2,11 +2,14 @@ build b1: copy a1
 build b2: copy a1
 build c1: copy b1
 build c2: copy b1
+build c3: phony
 build c4: copy b2
 build d1: copy c1
 build d2: copy c1
 build d3: copy c2
 build d4: copy c2
+build d5: phony
+build d6: phony
 build d7: copy c4
 build d8: copy c4
 build e1: copy d1
@@ -17,6 +20,10 @@ build e5: copy d3
 build e6: copy d3
 build e7: copy d4
 build e8: copy d4
+build e9: phony
+build e10: phony
+build e11: phony
+build e12: phony
 build e13: copy d7
 build e14: copy d7
 build e15: copy d8

--- a/tests/trimja/simple/expected.ninja
+++ b/tests/trimja/simple/expected.ninja
@@ -1,4 +1,7 @@
 build out1: copy in1
+build out2: phony
 build out3a: copy in3
 build out3b: copy in3
+build out4: phony
+build out5: phony
 build out6: copy in6

--- a/tests/trimja/simple_reversed/expected.ninja
+++ b/tests/trimja/simple_reversed/expected.ninja
@@ -1,4 +1,7 @@
 build out6: copy in6
+build out5: phony
+build out4: phony
 build out3b: copy in3
 build out3a: copy in3
+build out2: phony
 build out1: copy in1


### PR DESCRIPTION
Previously if we had a build command whose output was not needed we would avoid printing it in the resulting ninja file.

After handling `default`, we needed a new state where we wanted to include all inputs to `default`, but create `phony` rules for those inputs if there were no other build command that required them.  This allowed us not to have to edit the `default` statement and to not bring in dependencies if they were only required by `default`.

If we didn't, then running `ninja` would build everything mentioned in `default` every single time and wouldn't save us any time.  `default` is just a nice way of grouping a set of outputs.

Similarly, we want to do the same with `phony` commands in the future. So that something like `ninja all_tests` would build only the tests that had changed.

Thinking harder on the subject, it is very possible that build systems will have something like `ninja myexecutable.exe` that will mention an output of a non-phony rule. In this case we want to build it only if a dependent had changed.  But today we would not include that build edge and `ninja` would report an error - probably not what we want.

This commit changes `trimja` to output a build command for all outputs mentioned in the original `ninja` build file, but create `phony` edges for those not affected by the changed files. This way `ninja myexecutable.exe` would return a success code and report that there is no work to do.

In this commit we tidy up the string comparison code to string CR characters instead of messing around with binary outputs.