### PR TITLE
Always include validation edges

### DIFF
--- a/tests/trimja/validations/expected.ninja
+++ b/tests/trimja/validations/expected.ninja
@@ -1,8 +1,8 @@
 build outa: touch in |@ ignored
-build outb: phony
+build outb: phony |@ in
 build tmpa: touch in
 build tmpb: phony
 build tmpc: touch in
 build tmpd: phony
 build outc: touch tmpa |@ tmpb
-build outd: phony
+build outd: phony |@ tmpc


### PR DESCRIPTION
If a build edge is `phony`ed out because it is not required, currently we don't include the validation edges.  But `phony` rules themselves do take validation edges. For example,

```
rule touch
  command = touch $out
build test.txt: touch
build all: phony |@ test.txt
```

Would create `test.txt` when running `ninja all`.

The documentation for validation
(https://ninja-build.org/manual.html#validations) states:

> Validations listed on the build line cause the specified files to be
> added to the top level of the build graph (as if they were specified
> on the Ninja command line) whenever the build line is a transitive
> dependency of one of the targets specified on the command line or a
> default target.
>
> Validations are added to the build graph regardless of whether the
> output files of the build statement are dirty are not, and the dirty
> state of the build statement that outputs the file being used as a
> validation has no effect on the dirty state of the build statement
> that requested it.

I think it is more in keeping with this documentation if we include validation edges on build commands that we `phony` out.  If those edges are themselves not required then they will also be `phony` edges.  This commit makes that change.