### PR TITLE
Swap CMake to ninja generator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,6 +31,7 @@ jobs:
         -DCMAKE_C_COMPILER=${{ matrix.compiler.c }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DCMAKE_UNITY_BUILD=ON
+        ${{ matrix.os != 'windows-latest' && '-G Ninja' || ''}}
         -S ${{ github.workspace }}
     - name: Build
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}


### PR DESCRIPTION
When not using MSVC, use the ninja generator for CMake.  This should
give us a bit of a speed-up and we should really be using ninja stuff
as much as possible.

Using MSVC, CMake, and ninja together is difficult as it seems like we
would need to run the MSVC script to set up environment variables.  So
for now we just leave this configuration.