### PR TITLE
Take `std::string_view` on `Graph` methods

### DIFF
--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -28,18 +28,18 @@ namespace trimja {
 
 Graph::Graph() = default;
 
-std::size_t Graph::addPath(const std::string& path) {
+std::size_t Graph::addPath(std::string_view path) {
   const std::size_t nextIndex = m_inputToOutput.size();
   const auto [it, inserted] = m_pathToIndex.emplace(path, nextIndex);
   if (inserted) {
     m_inputToOutput.emplace_back();
     m_outputToInput.emplace_back();
-    m_path.push_back(path);
+    m_path.emplace_back(path);
   }
   return it->second;
 }
 
-bool Graph::hasPath(const std::string& path) const {
+bool Graph::hasPath(std::string_view path) const {
   return m_pathToIndex.contains(path);
 }
 
@@ -79,7 +79,7 @@ const std::set<std::size_t>& Graph::in(std::size_t pathIndex) const {
   return m_outputToInput[pathIndex];
 }
 
-std::size_t Graph::getPath(const std::string& path) const {
+std::size_t Graph::getPath(std::string_view path) const {
   return m_pathToIndex.find(path)->second;
 }
 

--- a/src/graph.h
+++ b/src/graph.h
@@ -25,15 +25,27 @@
 
 #include <set>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 
 namespace trimja {
 
 class Graph {
+  struct TransparentHash {
+    using is_transparent = void;
+    std::size_t operator()(const std::string& v) const {
+      return std::hash<std::string_view>{}(v);
+    }
+    std::size_t operator()(std::string_view v) const {
+      return std::hash<std::string_view>{}(v);
+    }
+  };
+
   // A look up from path to vertex index.
   // TODO: Change the key to `std::string_view`
-  std::unordered_map<std::string, std::size_t> m_pathToIndex;
+  std::unordered_map<std::string, std::size_t, TransparentHash, std::equal_to<>>
+      m_pathToIndex;
 
   // An adjacency list of input -> output
   std::vector<std::set<std::size_t>> m_inputToOutput;
@@ -49,9 +61,9 @@ class Graph {
  public:
   Graph();
 
-  std::size_t addPath(const std::string& path);
+  std::size_t addPath(std::string_view path);
 
-  bool hasPath(const std::string& path) const;
+  bool hasPath(std::string_view path) const;
 
   std::size_t addDefault();
 
@@ -64,7 +76,7 @@ class Graph {
   const std::set<std::size_t>& out(std::size_t pathIndex) const;
   const std::set<std::size_t>& in(std::size_t pathIndex) const;
 
-  std::size_t getPath(const std::string& path) const;
+  std::size_t getPath(std::string_view path) const;
 
   std::size_t size() const;
 };

--- a/src/trimutil.cpp
+++ b/src/trimutil.cpp
@@ -273,7 +273,7 @@ class Parser {
 
  public:
   std::size_t getPathIndex(std::string_view path) {
-    const std::size_t index = m_graph.addPath(std::string(path));
+    const std::size_t index = m_graph.addPath(path);
     if (index >= m_nodeToCommand.size()) {
       m_nodeToCommand.resize(index + 1,
                              std::numeric_limits<std::size_t>::max());


### PR DESCRIPTION
Use the same trick as `trimutil.cpp` to get a transparent hash to allow lookups in `std::unordered_map<std::string, T>` by `std::string_view`.

Update the method signatures and remove temporary `std::string` construction.