### PR TITLE
Remove several string allocations

### DIFF
--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -34,7 +34,7 @@ std::size_t Graph::addPath(std::string_view path) {
   if (inserted) {
     m_inputToOutput.emplace_back();
     m_outputToInput.emplace_back();
-    m_path.emplace_back(path);
+    m_path.emplace_back(it->first);
   }
   return it->second;
 }

--- a/src/graph.h
+++ b/src/graph.h
@@ -52,8 +52,9 @@ class Graph {
   // An adjacency list of output -> Input
   std::vector<std::set<std::size_t>> m_outputToInput;
 
-  // names of paths
-  std::vector<std::string> m_path;
+  // Names of paths (this points to the keys in `m_pathToIndex`, which is always
+  // valid since `std::unordered_map` has pointer stability.
+  std::vector<std::string_view> m_path;
 
   std::size_t m_defaultIndex = std::numeric_limits<std::size_t>::max();
 

--- a/src/trimutil.cpp
+++ b/src/trimutil.cpp
@@ -66,13 +66,10 @@ class BasicScope {
  public:
   BasicScope() = default;
 
-  template <typename STRING>
-  std::string_view set(std::string_view key, STRING&& value) {
-    const auto [it, inserted] = m_variables.emplace(key, value);
-    if (!inserted) {
-      it->second = std::forward<STRING>(value);
-    }
-    return it->second;
+  std::string_view set(std::string_view key, std::string&& value) {
+    // `operator[]` does not support `is_transparent` and `emplace` may or
+    // may not move from `value` so this is the best way to avoid allocations
+    return m_variables.emplace(key, "").first->second = std::move(value);
   }
 
   bool appendValue(std::string& output, std::string_view name) const {


### PR DESCRIPTION
Reduce the number of `std::string`s needed (both temporary and permanent) to reduce the amount of allocations.