### PR TITLE
Fix `DepsReader` reading bug and improve error handling

### DIFF
--- a/src/depsreader.cpp
+++ b/src/depsreader.cpp
@@ -39,28 +39,24 @@ const std::size_t NINJA_MAX_RECORD_SIZE = 0b11'1111'1111'1111'1111;
 template <typename TYPE>
 TYPE readBinary(std::istream& in) {
   TYPE value;
-  if (!in.read(reinterpret_cast<char*>(&value), sizeof(value))) {
-    if (in.rdstate() == std::ios::badbit) {
-      throw std::runtime_error("Logical error reading stream");
-    } else if (in.rdstate() == std::ios::failbit) {
-      throw std::runtime_error("Error reading stream");
-    } else {
-      throw std::runtime_error("Unknown error reading file");
-    }
-  }
+  in.read(reinterpret_cast<char*>(&value), sizeof(value));
   return value;
 }
 
 }  // namespace
 
-DepsReader::DepsReader(std::istream& deps)
-    : m_deps(&deps), m_storage(), m_depsStorage() {
-  std::getline(*m_deps, m_storage);
+DepsReader::DepsReader(const std::filesystem::path& ninja_deps)
+    : m_deps(ninja_deps, std::ios_base::binary),
+      m_storage(),
+      m_depsStorage(),
+      m_filePath(ninja_deps) {
+  m_deps.exceptions(std::ios_base::failbit | std::ios_base::badbit);
+  std::getline(m_deps, m_storage);
   if (m_storage != "# ninjadeps") {
     throw std::runtime_error("Unable to find ninjadeps signature");
   }
 
-  const std::int32_t header = readBinary<std::int32_t>(*m_deps);
+  const std::int32_t header = readBinary<std::int32_t>(m_deps);
   if (header != 4) {
     throw std::runtime_error("Only version 4 supported of ninjadeps");
   }
@@ -68,38 +64,43 @@ DepsReader::DepsReader(std::istream& deps)
 
 std::variant<PathRecordView, DepsRecordView, std::monostate>
 DepsReader::read() {
-  if (m_deps->peek() == EOF) {
-    return std::monostate();
-  }
-  const std::uint32_t rawRecordSize = readBinary<std::uint32_t>(*m_deps);
-  const std::uint32_t recordSize = rawRecordSize & 0x7FFFFFFF;
-  if (recordSize > NINJA_MAX_RECORD_SIZE) {
-    throw std::runtime_error("Record exceeding the maximum size found");
-  }
-  if (const bool isPathRecord = (rawRecordSize >> 31) == 0) {
-    const std::uint32_t pathSize = recordSize - sizeof(std::uint32_t);
-    m_storage.resize(pathSize);
-    m_deps->read(m_storage.data(), pathSize);
-    const auto end = m_storage.end();
-    const std::size_t padding =
-        (end[-1] == '\0') + (end[-2] == '\0') + (end[-3] == '\0');
-    m_storage.erase(m_storage.size() - padding);
-    const std::uint32_t checksum = readBinary<std::uint32_t>(*m_deps);
-    const std::int32_t id = ~checksum;
-    return PathRecordView{id, m_storage};
-  } else {
-    const std::int32_t outIndex = readBinary<std::int32_t>(*m_deps);
-    const ninja_clock::time_point mtime =
-        readBinary<ninja_clock::time_point>(*m_deps);
-    const std::uint32_t numDependencies =
-        (recordSize - sizeof(std::int32_t) - 2 * sizeof(std::uint32_t)) /
-        sizeof(std::int32_t);
-    m_depsStorage.resize(numDependencies);
-    std::generate_n(m_depsStorage.begin(), numDependencies,
-                    [&] { return readBinary<std::int32_t>(*m_deps); });
-    return DepsRecordView{
-        outIndex, std::chrono::clock_cast<std::chrono::file_clock>(mtime),
-        m_depsStorage};
+  try {
+    if (m_deps.peek() == EOF) {
+      return std::monostate();
+    }
+    const std::uint32_t rawRecordSize = readBinary<std::uint32_t>(m_deps);
+    const std::uint32_t recordSize = rawRecordSize & 0x7FFFFFFF;
+    if (recordSize > NINJA_MAX_RECORD_SIZE) {
+      throw std::runtime_error("Record exceeding the maximum size found");
+    }
+    if (const bool isPathRecord = (rawRecordSize >> 31) == 0) {
+      const std::uint32_t pathSize = recordSize - sizeof(std::uint32_t);
+      m_storage.resize(pathSize);
+      m_deps.read(m_storage.data(), pathSize);
+      const auto end = m_storage.end();
+      const std::size_t padding =
+          (end[-1] == '\0') + (end[-2] == '\0') + (end[-3] == '\0');
+      m_storage.erase(m_storage.size() - padding);
+      const std::uint32_t checksum = readBinary<std::uint32_t>(m_deps);
+      const std::int32_t id = ~checksum;
+      return PathRecordView{id, m_storage};
+    } else {
+      const std::int32_t outIndex = readBinary<std::int32_t>(m_deps);
+      const ninja_clock::time_point mtime =
+          readBinary<ninja_clock::time_point>(m_deps);
+      const std::uint32_t numDependencies =
+          (recordSize - sizeof(std::int32_t) - 2 * sizeof(std::uint32_t)) /
+          sizeof(std::int32_t);
+      m_depsStorage.resize(numDependencies);
+      std::generate_n(m_depsStorage.begin(), numDependencies,
+                      [&] { return readBinary<std::int32_t>(m_deps); });
+      return DepsRecordView{
+          outIndex, std::chrono::clock_cast<std::chrono::file_clock>(mtime),
+          m_depsStorage};
+    }
+  } catch (const std::ios_base::failure& e) {
+    throw std::runtime_error(
+        std::format("Error reading {}: {}", m_filePath.string(), e.what()));
   }
 }
 

--- a/src/depsreader.h
+++ b/src/depsreader.h
@@ -24,7 +24,8 @@
 #define TRIMJA_DEPSREADER
 
 #include <chrono>
-#include <iosfwd>
+#include <filesystem>
+#include <fstream>
 #include <span>
 #include <variant>
 #include <vector>
@@ -45,12 +46,13 @@ struct DepsRecordView {
 };
 
 class DepsReader {
-  std::istream* m_deps;
+  std::ifstream m_deps;
   std::string m_storage;
   std::vector<std::int32_t> m_depsStorage;
+  std::filesystem::path m_filePath;
 
  public:
-  explicit DepsReader(std::istream& deps);
+  explicit DepsReader(const std::filesystem::path& ninja_deps);
 
   std::variant<PathRecordView, DepsRecordView, std::monostate> read();
 };

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -22,7 +22,6 @@
 
 #include "parser.h"
 
-#include "depsreader.h"
 #include "graph.h"
 #include "murmur_hash.h"
 
@@ -32,6 +31,7 @@
 #include <cassert>
 #include <fstream>
 #include <iostream>
+#include <span>
 
 namespace trimja {
 

--- a/src/trimutil.cpp
+++ b/src/trimutil.cpp
@@ -95,8 +95,7 @@ void markInputsAsRequired(Graph& graph,
 void parseDepFile(const std::filesystem::path& ninjaDeps,
                   Graph& graph,
                   BuildContext& ctx) {
-  std::ifstream deps(ninjaDeps);
-  DepsReader reader(deps);
+  DepsReader reader(ninjaDeps);
   std::vector<std::size_t> lookup;
   while (true) {
     const auto record = reader.read();


### PR DESCRIPTION
`DepsReader` reads a binary file but was not passed an `std::ifstream` in binary mode.  This commit changes this component to take the file path in the constructor so that we guarantee we open the file in the correct mode.  This also allows us to throw a nicer error message that mentions the file name when things go wrong.

Use the `std::ifstream::exceptions` method instead of manually checking the state and then throwing.