### PR TITLE
Add iterators to `DepsReader`

### DIFF
--- a/src/depsreader.h
+++ b/src/depsreader.h
@@ -52,9 +52,33 @@ class DepsReader {
   std::filesystem::path m_filePath;
 
  public:
+  struct sentinel {};
+
+  class iterator {
+    DepsReader* m_reader;
+    std::variant<PathRecordView, DepsRecordView> m_entry;
+
+   public:
+    using difference_type = std::ptrdiff_t;
+    using value_type = std::variant<PathRecordView, DepsRecordView>;
+
+    iterator(DepsReader* reader);
+
+    const value_type& operator*() const;
+
+    iterator& operator++();
+    void operator++(int);
+    friend bool operator==(const iterator& iter, sentinel s);
+    friend bool operator!=(const iterator& iter, sentinel s);
+  };
+
+ public:
   explicit DepsReader(const std::filesystem::path& ninja_deps);
 
-  std::variant<PathRecordView, DepsRecordView, std::monostate> read();
+  bool read(std::variant<PathRecordView, DepsRecordView>* output);
+
+  iterator begin();
+  sentinel end();
 };
 
 }  // namespace trimja

--- a/src/logreader.cpp
+++ b/src/logreader.cpp
@@ -48,7 +48,30 @@ std::array<std::string_view, N> splitOnTab(std::string_view in) {
 static_assert(std::input_iterator<LogReader::iterator>);
 
 LogReader::iterator::iterator(LogReader* reader) : m_reader(reader), m_entry() {
-  m_reader->read(&m_entry);
+  ++(*this);
+}
+
+const LogEntry& LogReader::iterator::operator*() const {
+  return m_entry;
+}
+
+LogReader::iterator& LogReader::iterator::operator++() {
+  if (!m_reader->read(&m_entry)) {
+    m_reader = nullptr;
+  }
+  return *this;
+}
+
+void LogReader::iterator::operator++(int) {
+  ++*this;
+}
+
+bool operator==(const LogReader::iterator& iter, LogReader::sentinel) {
+  return iter.m_reader == nullptr;
+}
+
+bool operator!=(const LogReader::iterator& iter, LogReader::sentinel) {
+  return iter.m_reader != nullptr;
 }
 
 LogReader::LogReader(std::istream& logs) : m_logs(&logs), m_nextLine() {
@@ -97,14 +120,6 @@ LogReader::iterator LogReader::begin() {
 
 LogReader::sentinel LogReader::end() {
   return sentinel();
-}
-
-bool operator==(const LogReader::iterator& iter, LogReader::sentinel) {
-  return iter.m_reader == nullptr;
-}
-
-bool operator!=(const LogReader::iterator& iter, LogReader::sentinel) {
-  return iter.m_reader != nullptr;
 }
 
 }  // namespace trimja

--- a/src/logreader.h
+++ b/src/logreader.h
@@ -57,15 +57,10 @@ class LogReader {
 
     iterator(LogReader* reader);
 
-    const LogEntry& operator*() const { return m_entry; }
+    const LogEntry& operator*() const;
 
-    iterator& operator++() {
-      if (!m_reader->read(&m_entry)) {
-        m_reader = nullptr;
-      }
-      return *this;
-    }
-    void operator++(int) { ++*this; }
+    iterator& operator++();
+    void operator++(int);
     friend bool operator==(const iterator& iter, sentinel s);
     friend bool operator!=(const iterator& iter, sentinel s);
   };

--- a/src/trimutil.cpp
+++ b/src/trimutil.cpp
@@ -95,10 +95,9 @@ void markInputsAsRequired(Graph& graph,
 void parseDepFile(const std::filesystem::path& ninjaDeps,
                   Graph& graph,
                   BuildContext& ctx) {
-  DepsReader reader(ninjaDeps);
   std::vector<std::size_t> lookup;
-  while (true) {
-    const auto record = reader.read();
+  for (const std::variant<PathRecordView, DepsRecordView>& record :
+       DepsReader(ninjaDeps)) {
     switch (record.index()) {
       case 0: {
         const PathRecordView& view = std::get<PathRecordView>(record);
@@ -116,8 +115,6 @@ void parseDepFile(const std::filesystem::path& ninjaDeps,
         }
         break;
       }
-      case 2:
-        return;
     }
   }
 }


### PR DESCRIPTION
Follow the same design as `LogReader` and add `begin()` and `end()` to `DepsReader`.  This allows us to use a range-for loop in `trimutil.cpp` and keeps things looking tidy.

Update the iterator constructors to call `++*this;` instead of `read` as that will reset themselves to compare equal to the sentinel value.

Move all implementations for `LogReader::iterator` to the source file.