### PR TITLE
Be more flexible with affected files

### DIFF
--- a/tests/simple/changed.txt
+++ b/tests/simple/changed.txt
@@ -1,3 +1,4 @@
 in1
 in3
 in6
+not found


### PR DESCRIPTION
Allow affected files to not be mentioned within the input ninja file. This will occur when making changes to non-build files (e.g. a `README.md` file) and should not count as an error.  Instead we output a comment that it wasn't found to help diagnosing errors.

CMake can generate a ninja file with absolute paths, so we must attempt to look up absolute versions of each path if provided as relative.

To cover all bases, look up a relative path if affected paths are supplied as absolute paths.