### PR TITLE
Remove unused rules

### DIFF
--- a/tests/escaping/expected.ninja
+++ b/tests/escaping/expected.ninja
@@ -1,5 +1,3 @@
-rule copy
-  command = ninja --version $in -> $out
 build out1: phony
 build out$ 2a out$ 2b: phony
 build out3: phony

--- a/tests/passthrough/expected.ninja
+++ b/tests/passthrough/expected.ninja
@@ -2,6 +2,3 @@ foo = "bar"
 zulu = 42
 pool testPool
   depth = 3
-rule copy
-  command = cp $in $out
-  description = Copying $out

--- a/tests/variables/expected.ninja
+++ b/tests/variables/expected.ninja
@@ -3,9 +3,6 @@ pool hi
 pool bye
   depth = 100
 foo = 42
-rule copy
-  command = ninja --version $in -> $out foo=$foo bar=${bar} pool=$pool
-  pool = hi
 build out1: phony
 build out2: phony
 build out3: phony


### PR DESCRIPTION
CMake's ninja generator can generate a rule per translation object in some cases, which can be a huge number!  Removing unused rules will reduce the output size and make it easier to diagnose and debug problems.