### PR TITLE
Release v0.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.26.3)
-project(trimja VERSION 0.0.1)
+project(trimja VERSION 0.1.0)
 enable_testing()
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
This is the first public release of trimja!

trimja is able to handle ninja build files and to cut them down to only a small subset of build commands that are affected by a supplied list of files.

There are a few areas in which trimja can be improved.

  * `subninja` support
  * warning on using `depfile` without `deps = gcc`
  * additional error checking to cover cases such as recursive variable references and malformed `.ninja_log` and `.ninja_deps`