### PR TITLE
Simplify `Rule`

### DIFF
--- a/src/rule.h
+++ b/src/rule.h
@@ -25,8 +25,8 @@
 
 #include <ninja/eval_env.h>
 
-#include <array>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 struct EvalString;
@@ -35,7 +35,7 @@ namespace trimja {
 
 class Rule {
  public:
-  inline static const std::array<std::string_view, 11> reserved = {
+  inline static const std::string_view reserved[] = {
       "command",          "depfile", "dyndep", "description", "deps",
       "generator",        "pool",    "restat", "rspfile",     "rspfile_content",
       "msvc_deps_prefix",
@@ -43,9 +43,9 @@ class Rule {
 
  private:
   std::string_view m_name;
-  std::array<unsigned char, reserved.size() + 1>
-      m_lookup;  // TODO: pack into uint64_t
-  std::vector<EvalString> m_bindings;
+
+  // The `std::string_view*` points to an element of `reserved`
+  std::vector<std::pair<const std::string_view*, EvalString>> m_bindings;
 
  public:
   static std::size_t getLookupIndex(std::string_view varName);
@@ -56,8 +56,7 @@ class Rule {
 
   std::string_view name() const;
 
-  bool add(std::string_view varName, EvalString&& value);
-  bool add(std::string_view varName, const EvalString& value);
+  bool add(std::string_view varName, EvalString value);
 
   const EvalString* lookupVar(std::string_view varName) const;
 };


### PR DESCRIPTION
Reduce the `Rule::add` overloads and simplify the member variables to avoid an additional lookup.