### PR TITLE
Create a `.zip` package

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,6 +54,7 @@ jobs:
         files: |
           build/trimja-*-Linux.tar.gz
           build/trimja-*-win64.exe
+          build/trimja-*.zip
   format:
     runs-on: ubuntu-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,13 @@ target_compile_options(trimja PRIVATE
     $<$<CXX_COMPILER_ID:MSVC>:/W4>
 )
 install(TARGETS trimja RUNTIME DESTINATION bin)
+
+if(WIN32)
+    set(CPACK_GENERATOR ZIP NSIS)
+else()
+    set(CPACK_GENERATOR TGZ)
+endif()
+
 set(CPACK_PACKAGE_INSTALL_DIRECTORY trimja)
 set(CPACK_NSIS_MODIFY_PATH ON)
 set(CPACK_NSIS_IGNORE_LICENSE_PAGE ON)


### PR DESCRIPTION
As well as creating an NSIS installer for Windows, we want to create a `.zip` file.  This will be used by a future Github Action to install `trimja` - it will be far easier to unzip a directory compared to installing an executable.