### PR TITLE
Release v0.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.26.3)
-project(trimja VERSION 0.1.0)
+project(trimja VERSION 0.1.1)
 enable_testing()
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
  * Fix include and subninja paths not working if `trimja` is not run from the same directory as the ninja build file