### PR TITLE
Add `--builddir` flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(
     trimja
     src/trimja.m.cpp
     src/basicscope.cpp
+    src/builddirutil.cpp
     src/depsreader.cpp
     src/edgescope.cpp
     src/graph.cpp
@@ -170,6 +171,14 @@ set_tests_properties(
     PROPERTIES FIXTURES_REQUIRED trimja.snapshot.simple.fixture
 )
 
+# --builddir
+add_test(
+    NAME trimja.--builddir
+    COMMAND trimja -f builddir/build.ninja --builddir
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests
+)
+set_property(TEST trimja.--builddir PROPERTY PASS_REGULAR_EXPRESSION "builddir\/x64\/build")
+
 # Snapshot tests
 foreach(TEST ${TRIMJA_TESTS})
     add_test(
@@ -180,6 +189,13 @@ foreach(TEST ${TRIMJA_TESTS})
     set_tests_properties(
         trimja.snapshot.${TEST}
         PROPERTIES FIXTURES_REQUIRED trimja.snapshot.${TEST}.fixture
+    )
+
+    # Check that --builddir at least returns success on all tests
+    add_test(
+        NAME trimja.smoke.builddir.${TEST}
+        COMMAND trimja -f ${TEST}/build.ninja --builddir
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests
     )
 endforeach()
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ The following instruction on how to use trimja can be found by running
 `trimja --help` or `trimja -h`.
 
 ```
-Usage:
-  trimja [--version] [--help] [--file <path>]
-      [--write | --output <path>] [--affected <path> | -] [--explain]
-
 trimja is a tool to create a smaller ninja build file containing only those
 build commands that relate to a specified set of files. This is commonly used
 to improve CI performance for pull requests.
@@ -27,6 +23,30 @@ run of the input ninja build file in order to correctly remove build commands.
 Note that with simple ninja input files it is possible for ninja to not
 generate either '.ninja_log' or '.ninja_deps', and in this case trimja will
 work as expected.
+
+Usage:
+$ trimja --version
+    Print out the version of trimja
+
+$ trimja --help
+    Print out this help dialog
+
+$ trimja --builddir [-f FILE]
+    Print out the $builddir path in the ninja build file relative to the cwd
+
+$ trimja [-f FILE] [--write | -o OUT] [--affected PATH | -] [--explain]
+    Trim down the ninja build file to only required outputs and inputs
+
+Options:
+  -f FILE, --file=FILE      path to input ninja build file [default=build.ninja]
+  -a PATH, --affected=PATH  path to file containing affected file paths
+  -                         read affected file paths from stdin
+  -o OUT, --output=OUT      output file path [default=stdout]
+  -w, --write               overwrite input ninja build file
+  --explain                 print why each part of the build file was kept
+  --builddir                print the $builddir variable relative to the cwd
+  -h, --help                print help
+  -v, --version             print trimja version
 
 Examples:
 
@@ -39,16 +59,6 @@ Build only those commands that relate to files that differ from the 'main' git
 branch, note the lone '-' argument to specify we are reading from stdin,
   $ git diff main --name-only | trimja - --write
   $ ninja
-
-Options:
-  -f FILE, --file=FILE      path to input ninja build file [default=build.ninja]
-  -a FILE, --affected=FILE  path to file containing affected file paths
-  -                         read affected file paths from stdin
-  -o FILE, --output=FILE    output file path [default=stdout]
-  -w, --write               overwrite input ninja build file
-  --explain                 print why each part of the build file was kept
-  -h, --help                print help
-  -v, --version             print trimja version
 
 For more information visit the homepage https://github.com/elliotgoodrich/trimja
 ```

--- a/src/builddirutil.cpp
+++ b/src/builddirutil.cpp
@@ -1,0 +1,125 @@
+// MIT License
+//
+// Copyright (c) 2024 Elliot Goodrich
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "builddirutil.h"
+
+#include "basicscope.h"
+#include "manifestparser.h"
+
+#include <format>
+#include <fstream>
+#include <variant>
+
+namespace trimja {
+
+namespace {
+
+struct BuildDirContext {
+  BasicScope fileScope;
+
+  BuildDirContext() = default;
+
+  static void consume(PathRangeReader&& range) {
+    for ([[maybe_unused]] const EvalString& r : range) {
+    }
+  }
+
+  static void consume(LetRangeReader&& range) {
+    for (VariableReader&& r : range) {
+      [[maybe_unused]] const std::string_view name = r.name();
+      [[maybe_unused]] const EvalString& value = r.value();
+    }
+  }
+
+  void parse(const std::filesystem::path& ninjaFile,
+             const std::string& ninjaFileContents) {
+    for (auto&& part : ManifestReader(ninjaFile, ninjaFileContents)) {
+      std::visit(*this, part);
+    }
+  }
+
+  void operator()(PoolReader& r) const {
+    [[maybe_unused]] const std::string_view name = r.name();
+    consume(r.variables());
+  }
+
+  void operator()(BuildReader& r) const {
+    consume(r.out());
+    consume(r.implicitOut());
+    [[maybe_unused]] const std::string_view ruleName = r.name();
+    consume(r.in());
+    consume(r.implicitIn());
+    consume(r.orderOnlyDeps());
+    consume(r.validations());
+    consume(r.variables());
+  }
+
+  void operator()(RuleReader& r) const {
+    [[maybe_unused]] const std::string_view name = r.name();
+    consume(r.variables());
+  }
+
+  void operator()(DefaultReader& r) const { consume(r.paths()); }
+
+  void operator()(VariableReader& r) {
+    const std::string_view name = r.name();
+    std::string result;
+    evaluate(result, r.value(), fileScope);
+    fileScope.set(name, std::move(result));
+  }
+
+  void operator()(IncludeReader& r) {
+    const std::filesystem::path file = [&] {
+      const EvalString& pathEval = r.path();
+      std::string path;
+      evaluate(path, pathEval, fileScope);
+      return std::filesystem::path(r.parent()).remove_filename() / path;
+    }();
+
+    if (!std::filesystem::exists(file)) {
+      throw std::runtime_error(
+          std::format("Unable to find {}!", file.string()));
+    }
+    std::stringstream ninjaCopy;
+    std::ifstream ninja(file);
+    ninjaCopy << ninja.rdbuf();
+    parse(file, ninjaCopy.str());
+  }
+
+  void operator()(SubninjaReader&) const {
+    throw std::runtime_error("subninja not yet supported");
+  }
+};
+
+}  // namespace
+
+std::filesystem::path BuildDirUtil::builddir(
+    const std::filesystem::path& ninjaFile,
+    const std::string& ninjaFileContents) {
+  BuildDirContext ctx;
+  ctx.parse(ninjaFile, ninjaFileContents);
+  std::string builddir;
+  ctx.fileScope.appendValue(builddir, "builddir");
+  return std::filesystem::path(ninjaFile).remove_filename() / builddir;
+}
+
+}  // namespace trimja

--- a/src/builddirutil.h
+++ b/src/builddirutil.h
@@ -1,0 +1,38 @@
+// MIT License
+//
+// Copyright (c) 2024 Elliot Goodrich
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TRIMJA_BUILDDIRUTIL
+#define TRIMJA_BUILDDIRUTIL
+
+#include <filesystem>
+#include <string>
+
+namespace trimja {
+
+struct BuildDirUtil {
+  static std::filesystem::path builddir(const std::filesystem::path& ninjaFile,
+                                        const std::string& ninjaFileContents);
+};
+
+}  // namespace trimja
+
+#endif  // TRIMJA_BUILDDIRUTIL

--- a/src/trimutil.cpp
+++ b/src/trimutil.cpp
@@ -46,12 +46,6 @@ namespace trimja {
 
 namespace {
 
-template <typename RANGE>
-void consume(RANGE&& range) {
-  for ([[maybe_unused]] auto&& r : range) {
-  }
-}
-
 struct BuildCommand {
   enum Resolution {
     // Print the entire build command
@@ -126,6 +120,18 @@ struct BuildContext {
     static_assert(phonyIndex == 0);
     static_assert(defaultIndex == 1);
     return ruleIndex < 2;
+  }
+
+  static void consume(PathRangeReader&& range) {
+    for ([[maybe_unused]] const EvalString& r : range) {
+    }
+  }
+
+  static void consume(LetRangeReader&& range) {
+    for (VariableReader&& r : range) {
+      [[maybe_unused]] const std::string_view name = r.name();
+      [[maybe_unused]] const EvalString& value = r.value();
+    }
   }
 
   BuildContext() {


### PR DESCRIPTION
Add a command line flag to print out the path of the directory that ninja will be outputting `.ninja_log` and `.ninja_deps`.  This will be based on the `$builddir` variable as well as the relative path to the ninja build file.

`--builddir` will be used by `trimja-action` to locate the build files in order to add them to Github cache.

During this I discovered that the `consume` function doesn't work with variable ranges since it never reads the name or value from the `VariableReader`.  This was a bug that could affect trimming if there was ever 2+ variables allowed underneath a `pool`.

`consume` has been moved to a `static` function so that it doesn't conflict with the other free functions when doing a unity build.