### PR TITLE
Build on older ubuntu

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         build_type: [Debug, Release]
         compiler: [
-          {os: ubuntu-24.04, cpp: clang++, c: clang},
+          {os: ubuntu-latest, cpp: clang++, c: clang},
           {os: windows-latest, cpp: cl, c: cl},
         ]
     runs-on: ${{ matrix.compiler.os }}

--- a/src/builddirutil.cpp
+++ b/src/builddirutil.cpp
@@ -25,7 +25,6 @@
 #include "basicscope.h"
 #include "manifestparser.h"
 
-#include <format>
 #include <fstream>
 #include <variant>
 
@@ -96,8 +95,11 @@ struct BuildDirContext {
     }();
 
     if (!std::filesystem::exists(file)) {
-      throw std::runtime_error(
-          std::format("Unable to find {}!", file.string()));
+      std::string msg;
+      msg += "Unable to find ";
+      msg += file.string();
+      msg += "!";
+      throw std::runtime_error(msg);
     }
     std::stringstream ninjaCopy;
     std::ifstream ninja(file);

--- a/src/logreader.cpp
+++ b/src/logreader.cpp
@@ -25,7 +25,7 @@
 
 #include <array>
 #include <cassert>
-#include <ranges>
+#include <charconv>
 
 namespace trimja {
 namespace {
@@ -104,7 +104,7 @@ bool LogReader::read(LogEntry* output) {
   {
     ninja_clock::rep ticks;
     std::from_chars(parts[2].data(), parts[2].data() + parts[2].size(), ticks);
-    output->mtime = std::chrono::clock_cast<std::chrono::file_clock>(
+    output->mtime = ninja_clock::to_file_clock(
         ninja_clock::time_point{ninja_clock::duration{ticks}});
   }
 

--- a/src/manifestparser.cpp
+++ b/src/manifestparser.cpp
@@ -24,7 +24,6 @@
 
 #include <ninja/lexer.h>
 
-#include <format>
 #include <stdexcept>
 
 namespace trimja {
@@ -34,9 +33,12 @@ namespace {
 void expectToken(Lexer* lexer, Lexer::Token expected) {
   const Lexer::Token token = lexer->ReadToken();
   if (token != expected) {
-    throw std::runtime_error(std::format("Expected {} but got {}",
-                                         Lexer::TokenName(expected),
-                                         Lexer::TokenName(token)));
+    std::string msg;
+    msg += "Expected ";
+    msg += Lexer::TokenName(expected);
+    msg += " but got ";
+    msg += Lexer::TokenName(token);
+    throw std::runtime_error(msg);
   }
 }
 
@@ -328,8 +330,10 @@ ManifestReader::iterator& ManifestReader::iterator::operator++() {
       m_lexer = nullptr;
       break;
     default: {
-      throw std::runtime_error(
-          std::format("Unexpected token {}", Lexer::TokenName(token)));
+      std::string msg;
+      msg += "Unexpected token ";
+      msg += Lexer::TokenName(token);
+      throw std::runtime_error(msg);
     }
   }
 

--- a/src/ninja_clock.cpp
+++ b/src/ninja_clock.cpp
@@ -22,6 +22,8 @@
 
 #include "ninja_clock.h"
 
+namespace trimja {
+
 namespace {
 
 #if defined(_MSC_VER)
@@ -41,6 +43,21 @@ const std::uint64_t offset = 0;
 
 }  // namespace
 
+trimja::ninja_clock::time_point ninja_clock::from_file_clock(
+    std::chrono::file_clock::time_point t) {
+  return trimja::ninja_clock::time_point(
+      trimja::ninja_clock::duration(t.time_since_epoch().count() - offset));
+}
+
+std::chrono::file_clock::time_point ninja_clock::to_file_clock(
+    trimja::ninja_clock::time_point t) {
+  return std::chrono::file_clock::time_point(
+      std::chrono::file_clock::duration(t.time_since_epoch().count() + offset));
+}
+
+}  // namespace trimja
+
+#if 0
 namespace std {
 namespace chrono {
 
@@ -48,15 +65,16 @@ trimja::ninja_clock::time_point
 clock_time_conversion<trimja::ninja_clock, file_clock>::operator()(
     file_clock::time_point t) {
   return trimja::ninja_clock::time_point(
-      trimja::ninja_clock::duration(t.time_since_epoch().count() - offset));
+      trimja::ninja_clock::duration(t.time_since_epoch().count() - trimja::offset));
 };
 
 file_clock::time_point
 clock_time_conversion<file_clock, trimja::ninja_clock>::operator()(
     trimja::ninja_clock::time_point t) {
   return file_clock::time_point(
-      file_clock::duration(t.time_since_epoch().count() + offset));
+      file_clock::duration(t.time_since_epoch().count() + trimja::offset));
 }
 
 }  // namespace chrono
 }  // namespace std
+#endif

--- a/src/ninja_clock.h
+++ b/src/ninja_clock.h
@@ -36,10 +36,18 @@ struct ninja_clock {
   using duration = std::chrono::duration<rep, period>;
   using time_point = std::chrono::time_point<ninja_clock>;
   static const bool is_steady = false;
+
+  static trimja::ninja_clock::time_point from_file_clock(
+      std::chrono::file_clock::time_point t);
+
+  static std::chrono::file_clock::time_point to_file_clock(
+      trimja::ninja_clock::time_point t);
 };
 
 }  // namespace trimja
 
+#if 0
+// Supported only with later versions of C++20
 namespace std {
 namespace chrono {
 
@@ -55,5 +63,5 @@ struct clock_time_conversion<file_clock, trimja::ninja_clock> {
 
 }  // namespace chrono
 }  // namespace std
-
+#endif
 #endif


### PR DESCRIPTION
To be able to run trimja on all Github supported runners for trimja-action, we need to be able to build on older versions of ubuntu in order to avoid glibc runtime errors.