### PR TITLE
Add `BasicScope::clearValue` and documentation

### DIFF
--- a/src/basicscope.cpp
+++ b/src/basicscope.cpp
@@ -34,6 +34,13 @@ std::string_view BasicScope::set(std::string_view key, std::string&& value) {
              std::move(value);
 }
 
+std::string& BasicScope::clearValue(std::string_view key) {
+  std::string& value =
+      m_variables.emplace(fixed_string::create(key), "").first->second;
+  value.clear();
+  return value;
+}
+
 bool BasicScope::appendValue(std::string& output, std::string_view name) const {
   const auto it = m_variables.find(fixed_string::make_temp(name));
   if (it == m_variables.end()) {

--- a/src/basicscope.h
+++ b/src/basicscope.h
@@ -31,14 +31,26 @@
 
 namespace trimja {
 
+// `BasicScope` holds a set of key-value pairs that represent ninja variables.
 class BasicScope {
   std::unordered_map<fixed_string, std::string> m_variables;
 
  public:
+  // Create a `BasicScope` with no values.
   BasicScope();
 
+  // Set the value of the specified `key` to the specified `value` and return a
+  // `std::string_view` to to the inserted value.  Note that `value` will be
+  // moved from unconditionally.
   std::string_view set(std::string_view key, std::string&& value);
 
+  // Insert an empty value for the specified `key`, or clear the existing
+  // `value` if there is one and return a reference to this empty value in both
+  // cases.
+  std::string& clearValue(std::string_view key);
+
+  // If there is a key with the specified `name`, then append its value to the
+  // specified `output` and return true; otherwise do nothing and return false.
   bool appendValue(std::string& output, std::string_view name) const;
 };
 

--- a/src/builddirutil.cpp
+++ b/src/builddirutil.cpp
@@ -81,9 +81,7 @@ struct BuildDirContext {
 
   void operator()(VariableReader& r) {
     const std::string_view name = r.name();
-    std::string result;
-    evaluate(result, r.value(), fileScope);
-    fileScope.set(name, std::move(result));
+    evaluate(fileScope.clearValue(name), r.value(), fileScope);
   }
 
   void operator()(IncludeReader& r) {

--- a/src/edgescope.cpp
+++ b/src/edgescope.cpp
@@ -54,5 +54,9 @@ std::string_view EdgeScopeBase::set(std::string_view key, std::string&& value) {
   return m_local.set(key, std::move(value));
 }
 
+std::string& EdgeScopeBase::clearValue(std::string_view key) {
+  return m_local.clearValue(key);
+}
+
 }  // namespace detail
 }  // namespace trimja

--- a/src/edgescope.h
+++ b/src/edgescope.h
@@ -53,6 +53,7 @@ class EdgeScopeBase {
                 std::span<const std::string> outs);
 
   std::string_view set(std::string_view key, std::string&& value);
+  std::string& clearValue(std::string_view key);
 };
 
 }  // namespace detail
@@ -68,6 +69,7 @@ class EdgeScope : private detail::EdgeScopeBase {
             std::span<const std::string> outs)
       : detail::EdgeScopeBase(rule, ins, outs), m_parent(parent) {}
 
+  using detail::EdgeScopeBase::clearValue;
   using detail::EdgeScopeBase::set;
 
   bool appendValue(std::string& output, std::string_view name) const {

--- a/src/trimutil.cpp
+++ b/src/trimutil.cpp
@@ -243,9 +243,7 @@ struct BuildContext {
 
     for (VariableReader v : r.variables()) {
       const std::string_view name = v.name();
-      std::string result;
-      evaluate(result, v.value(), scope);
-      scope.set(name, std::move(result));
+      evaluate(scope.clearValue(name), v.value(), scope);
     }
 
     const std::size_t partsIndex = parts.size();
@@ -343,9 +341,7 @@ struct BuildContext {
 
   void operator()(VariableReader& r) {
     std::string_view name = r.name();
-    std::string result;
-    evaluate(result, r.value(), fileScope);
-    fileScope.set(name, std::move(result));
+    evaluate(fileScope.clearValue(name), r.value(), fileScope);
     parts.emplace_back(r.start(), r.bytesParsed());
   }
 


### PR DESCRIPTION
Add documentation to the `BasicScope` class and add a new method `clearValue`.  This method allows us to evaluate variables and put them in a `BasicScope` without creating a temporary variable. In the case that we have duplicate keys we will remove some allocations.