### PR TITLE
Update documentation

### DIFF
--- a/src/basicscope.cpp
+++ b/src/basicscope.cpp
@@ -34,7 +34,7 @@ std::string_view BasicScope::set(std::string_view key, std::string&& value) {
              std::move(value);
 }
 
-std::string& BasicScope::clearValue(std::string_view key) {
+std::string& BasicScope::resetValue(std::string_view key) {
   std::string& value =
       m_variables.emplace(fixed_string::create(key), "").first->second;
   value.clear();

--- a/src/basicscope.h
+++ b/src/basicscope.h
@@ -31,29 +31,47 @@
 
 namespace trimja {
 
-// `BasicScope` holds a set of key-value pairs that represent ninja variables.
+/**
+ * @class BasicScope
+ * @brief Manages a scope of variables for evaluation and substitution.
+ */
 class BasicScope {
   std::unordered_map<fixed_string, std::string> m_variables;
 
  public:
-  // Create a `BasicScope` with no values.
+  /**
+   * @brief Constructs an empty BasicScope.
+   */
   BasicScope();
 
-  // Set the value of the specified `key` to the specified `value` and return a
-  // `std::string_view` to to the inserted value.  Note that `value` will be
-  // moved from unconditionally.
+  /**
+   * @brief Sets a variable in the scope.
+   * @param key The name of the variable.
+   * @param value The value of the variable.
+   * @return A reference to the inserted value.
+   */
   std::string_view set(std::string_view key, std::string&& value);
 
-  // Insert an empty value for the specified `key`, or clear the existing
-  // `value` if there is one and return a reference to this empty value in both
-  // cases.
-  std::string& clearValue(std::string_view key);
+  /**
+   * @brief Resets the value of a variable in the scope.
+   *
+   * This method sets the value associated with the specified key to an empty
+   * string. If the key does not exist, it inserts the key with an empty value.
+   *
+   * @param key The name of the variable to reset.
+   * @return A reference to the reset value.
+   */
+  std::string& resetValue(std::string_view key);
 
-  // If there is a key with the specified `name`, then append its value to the
-  // specified `output` and return true; otherwise do nothing and return false.
+  /**
+   * @brief Appends the value of a variable to the output string.
+   * @param output The string to append the value to.
+   * @param name The name of the variable.
+   * @return Whether the variable was found in this scope.
+   */
   bool appendValue(std::string& output, std::string_view name) const;
 };
 
 }  // namespace trimja
 
-#endif
+#endif  // TRIMJA_BASICSCOPE

--- a/src/builddirutil.cpp
+++ b/src/builddirutil.cpp
@@ -81,7 +81,7 @@ struct BuildDirContext {
 
   void operator()(VariableReader& r) {
     const std::string_view name = r.name();
-    evaluate(fileScope.clearValue(name), r.value(), fileScope);
+    evaluate(fileScope.resetValue(name), r.value(), fileScope);
   }
 
   void operator()(IncludeReader& r) {

--- a/src/builddirutil.h
+++ b/src/builddirutil.h
@@ -28,7 +28,18 @@
 
 namespace trimja {
 
+/**
+ * @struct BuildDirUtil
+ * @brief Utility functions for finding the build directory for a Ninja file.
+ */
 struct BuildDirUtil {
+  /**
+   * @brief Determines the build directory from the given Ninja file and its
+   * contents.
+   * @param ninjaFile The path to the Ninja file.
+   * @param ninjaFileContents The contents of the Ninja file.
+   * @return The path to the build directory.
+   */
   static std::filesystem::path builddir(const std::filesystem::path& ninjaFile,
                                         const std::string& ninjaFileContents);
 };

--- a/src/depsreader.h
+++ b/src/depsreader.h
@@ -34,17 +34,29 @@ namespace trimja {
 
 class Graph;
 
+/**
+ * @struct PathRecordView
+ * @brief Represents a view of a path record inside .ninja_deps
+ */
 struct PathRecordView {
   std::int32_t index;
   std::string_view path;
 };
 
+/**
+ * @struct DepsRecordView
+ * @brief Represents a view of a dependency record inside .ninja_deps
+ */
 struct DepsRecordView {
   std::int32_t outIndex;
   std::chrono::file_clock::time_point mtime;
   std::span<const std::int32_t> deps;
 };
 
+/**
+ * @class DepsReader
+ * @brief Reads dependency records from a .ninja_deps file
+ */
 class DepsReader {
   std::ifstream m_deps;
   std::string m_storage;
@@ -52,8 +64,16 @@ class DepsReader {
   std::filesystem::path m_filePath;
 
  public:
+  /**
+   * @struct sentinel
+   * @brief Sentinel type for the end of the iterator range.
+   */
   struct sentinel {};
 
+  /**
+   * @class iterator
+   * @brief Iterator for traversing dependency records in the deps file.
+   */
   class iterator {
     DepsReader* m_reader;
     std::variant<PathRecordView, DepsRecordView> m_entry;
@@ -62,22 +82,71 @@ class DepsReader {
     using difference_type = std::ptrdiff_t;
     using value_type = std::variant<PathRecordView, DepsRecordView>;
 
+    /**
+     * @brief Constructs an iterator for the given DepsReader.
+     * @param reader Pointer to the DepsReader.
+     */
     iterator(DepsReader* reader);
 
+    /**
+     * @brief Dereferences the iterator to get the current entry.
+     * @return The current entry.
+     */
     const value_type& operator*() const;
 
+    /**
+     * @brief Advances the iterator to the next entry in the file.
+     * @return Reference to the iterator.
+     */
     iterator& operator++();
+
+    /**
+     * @brief Advances the iterator to the next entry.
+     */
     void operator++(int);
+
+    /**
+     * @brief Compares the iterator with a sentinel for equality.
+     * @param iter The iterator to compare.
+     * @param s The sentinel to compare.
+     * @return Whether the iterator has read past the end of the file.
+     */
     friend bool operator==(const iterator& iter, sentinel s);
+
+    /**
+     * @brief Compares the iterator with a sentinel for inequality.
+     * @param iter The iterator to compare.
+     * @param s The sentinel to compare.
+     * @return Whether the iterator points to a valid entry, i.e. not past the
+     * end of the file.
+     */
     friend bool operator!=(const iterator& iter, sentinel s);
   };
 
  public:
+  /**
+   * @brief Constructs a DepsReader for the given Ninja deps file.
+   * @param ninja_deps The path to the Ninja .ninja_dep file.
+   */
   explicit DepsReader(const std::filesystem::path& ninja_deps);
 
+  /**
+   * @brief Reads the next dependency record from the deps file.
+   * @param output Pointer to the variant to store the read record.
+   * @return Whether a record was successfully read.
+   */
   bool read(std::variant<PathRecordView, DepsRecordView>* output);
 
+  /**
+   * @brief Gets an iterator to the beginning of the dependency records.
+   * @return An iterator to the beginning.
+   */
   iterator begin();
+
+  /**
+   * @brief Gets a sentinel representing the end of the dependency records.
+   * @return A sentinel representing the end.
+   */
   sentinel end();
 };
 

--- a/src/depswriter.h
+++ b/src/depswriter.h
@@ -31,10 +31,33 @@
 
 namespace trimja {
 
+/**
+ * @struct DepsWriter
+ * @brief A class to write dependencies to an output stream.
+ */
 struct DepsWriter {
+  /**
+   * @brief Constructs a DepsWriter with the given output stream.
+   *
+   * @param out The output stream to write dependencies to.
+   */
   explicit DepsWriter(std::ostream& out);
 
+  /**
+   * @brief Records a path and returns its associated node ID.
+   *
+   * @param path The path to record.
+   * @return The node ID associated with the recorded path.
+   */
   std::int32_t recordPath(std::string_view path);
+
+  /**
+   * @brief Records dependencies for a given output node.
+   *
+   * @param out The node ID of the output.
+   * @param mtime The modification time of the output.
+   * @param dependencies A span of node IDs representing the dependencies.
+   */
   void recordDependencies(std::int32_t out,
                           std::chrono::file_clock::time_point mtime,
                           std::span<const std::int32_t> dependencies);

--- a/src/edgescope.cpp
+++ b/src/edgescope.cpp
@@ -54,8 +54,8 @@ std::string_view EdgeScopeBase::set(std::string_view key, std::string&& value) {
   return m_local.set(key, std::move(value));
 }
 
-std::string& EdgeScopeBase::clearValue(std::string_view key) {
-  return m_local.clearValue(key);
+std::string& EdgeScopeBase::resetValue(std::string_view key) {
+  return m_local.resetValue(key);
 }
 
 }  // namespace detail

--- a/src/edgescope.h
+++ b/src/edgescope.h
@@ -53,25 +53,75 @@ class EdgeScopeBase {
                 std::span<const std::string> outs);
 
   std::string_view set(std::string_view key, std::string&& value);
-  std::string& clearValue(std::string_view key);
+  std::string& resetValue(std::string_view key);
 };
 
 }  // namespace detail
 
+/**
+ * @class EdgeScope
+ * @brief Manages the scope of variables for a specific build edge.
+ *
+ * The EdgeScope class is responsible for handling variable lookups and
+ * substitutions within the context of a specific build edge. It extends
+ * the functionality of EdgeScopeBase and interacts with a parent scope.
+ *
+ * @tparam SCOPE The type of the parent scope.
+ */
 template <typename SCOPE>
 class EdgeScope : private detail::EdgeScopeBase {
   SCOPE& m_parent;
 
  public:
+  /**
+   * @brief Constructs an EdgeScope with the given parent scope, rule, inputs,
+   * and outputs.
+   * @param parent The parent scope.
+   * @param rule The rule associated with the build edge.
+   * @param ins The input files for the build edge.
+   * @param outs The output files for the build edge.
+   */
   EdgeScope(SCOPE& parent,
             const Rule& rule,
             std::span<const std::string> ins,
             std::span<const std::string> outs)
       : detail::EdgeScopeBase(rule, ins, outs), m_parent(parent) {}
 
-  using detail::EdgeScopeBase::clearValue;
+  /**
+   * @brief Sets a local variable in the edge scope.
+   *
+   * This method sets a local variable with the given key and value within the
+   * edge scope. The variable is stored in the local scope and can be used for
+   * variable substitution during the build process.
+   *
+   * @param key The name of the variable to set.
+   * @param value The value to assign to the variable.
+   * @return A string view of the stored value.
+   */
   using detail::EdgeScopeBase::set;
 
+  /**
+   * @brief Resets the value of a variable in the scope.
+   *
+   * This method sets the value associated with the specified key to an empty
+   * string. If the key does not exist, it inserts the key with an empty value.
+   *
+   * @param key The name of the variable to reset.
+   * @return A reference to the reset value.
+   */
+  using detail::EdgeScopeBase::resetValue;
+
+  /**
+   * @brief Appends the value of a variable to the output string.
+   *
+   * This method looks up the value of the specified variable name and appends
+   * it to the output string. The lookup follows the order of precedence as
+   * described in the Ninja build manual.
+   *
+   * @param output The string to append the value to.
+   * @param name The name of the variable.
+   * @return Whether the variable was found in this scope.
+   */
   bool appendValue(std::string& output, std::string_view name) const {
     // From https://ninja-build.org/manual.html#ref_scope
     // Variable declarations indented in a build block are scoped to the build
@@ -107,4 +157,4 @@ class EdgeScope : private detail::EdgeScopeBase {
 
 }  // namespace trimja
 
-#endif
+#endif  // TRIMJA_EDGESCOPE

--- a/src/fixed_string.h
+++ b/src/fixed_string.h
@@ -27,35 +27,54 @@
 
 namespace trimja {
 
-// `fixed_string` is a non-null terminated string that cannot have its length
-// changed after construction.  It is useful as the key to an associative
-// container since these are immutable after construction.  It has no
-// small-string optimization (yet).
-//
-// Before we have heterogenous lookup in associative containers (e.g.
-// `is_transparent` on hash and equality) we can use the `make_temp` static
-// method to create a `const fixed_string&` that can be used to lookup
-// `std::string_view` values from containers.
+/**
+ * @class fixed_string
+ * @brief A non-null terminated string with a fixed length that cannot be
+ * changed after construction.
+ *
+ * This class is useful as the key to an associative container since these are
+ * immutable after construction. It has no small-string optimization (yet).
+ */
 class fixed_string {
   std::string_view m_data;
 
  public:
+  /**
+   * @struct copy_from_string_view_t
+   * @brief Helper struct to create a fixed_string from a std::string_view.
+   */
   struct copy_from_string_view_t {
     std::string_view data;
   };
 
-  // Create a `const fixed_string&` from the specified `str`.  The lifetime of
-  // the returned reference is the same as the lifetime of `str`.
+  /**
+   * @brief Create a temporary const fixed_string reference.
+   *
+   * The lifetime of the returned reference is the same as the lifetime of
+   * the std::string_view.
+   *
+   * @param str The string view to create the fixed_string from.
+   * @return A const reference to the created fixed_string.
+   */
   static const fixed_string& make_temp(const std::string_view& str) noexcept;
 
-  // Create an object that can construct a `fixed_string` from the specified
-  // `str`.
+  /**
+   * @brief Create an object that can construct a fixed_string from a string.
+   *
+   * @param str The string view to create the fixed_string from.
+   * @return A copy_from_string_view_t object containing the string view.
+   */
   static copy_from_string_view_t create(const std::string_view& str);
 
-  // Create a `fixed_string` from the specified `str`. We do not have a
-  // constructor from `std::string_view` in case users forget to call
-  // `make_temp` when looking up values and we construct a temporary
-  // `fixed_string`
+  /**
+   * @brief Construct a fixed_string from a string.
+   *
+   * We do not have a constructor from std::string_view in case users forget
+   * to call make_temp when looking up values and we construct a temporary
+   * fixed_string.
+   *
+   * @param str The copy_from_string_view_t object containing the string view.
+   */
   fixed_string(const copy_from_string_view_t& str);
 
   ~fixed_string();
@@ -63,19 +82,54 @@ class fixed_string {
   fixed_string(const fixed_string&) = delete;
   fixed_string& operator=(const fixed_string&) = delete;
 
+  /**
+   * @brief Implicit conversion operator to std::string_view.
+   *
+   * @return A std::string_view representing the fixed_string.
+   */
   operator std::string_view() const;
+
+  /**
+   * @brief Get a std::string_view of the fixed_string.
+   *
+   * @return A std::string_view representing the fixed_string.
+   */
   std::string_view view() const;
 };
 
+/**
+ * @brief Equality operator for fixed_string.
+ *
+ * @param lhs The left-hand side fixed_string.
+ * @param rhs The right-hand side fixed_string.
+ * @return Whether the fixed_strings are equal.
+ */
 bool operator==(const fixed_string& lhs, const fixed_string& rhs);
+
+/**
+ * @brief Inequality operator for fixed_string.
+ *
+ * @param lhs The left-hand side fixed_string.
+ * @param rhs The right-hand side fixed_string.
+ * @return Whether the fixed_strings are not equal.
+ */
 bool operator!=(const fixed_string& lhs, const fixed_string& rhs);
 
 }  // namespace trimja
 
 namespace std {
 
+/**
+ * @brief Specialization of std::hash for trimja::fixed_string.
+ */
 template <>
 struct hash<trimja::fixed_string> {
+  /**
+   * @brief Compute the hash value for a fixed_string.
+   *
+   * @param str The fixed_string to hash.
+   * @return The hash value of the fixed_string.
+   */
   size_t operator()(const trimja::fixed_string& str) const {
     return hash<std::string_view>{}(str.view());
   }

--- a/src/graph.h
+++ b/src/graph.h
@@ -34,6 +34,11 @@
 
 namespace trimja {
 
+/**
+ * @class Graph
+ * @brief Represents a directed graph where nodes are file paths and edges
+ * represent dependencies.
+ */
 class Graph {
   struct PathHash {
     std::size_t operator()(const fixed_string& v) const;
@@ -60,6 +65,9 @@ class Graph {
   std::size_t m_defaultIndex = std::numeric_limits<std::size_t>::max();
 
  public:
+  /**
+   * @brief Constructs an empty Graph.
+   */
   Graph();
 
   Graph(Graph&&) = default;
@@ -67,32 +75,94 @@ class Graph {
   Graph& operator=(Graph&&) = default;
   Graph& operator=(const Graph&) = delete;
 
-  // Add the specified `path` to the graph if it isn't already and then return
-  // the corresponding index to that path. `path` will be modified to be
-  // normalized.  Note that on windows, backslashes and forward slashes are
-  // accepted as valid path separators.  If `addPath` is called multiple times
-  // with a `path` that differs only by the slash type, then `path` will be
-  // updated to have the slashes of the first `path` called.
+  /**
+   * @brief Adds the path to the graph if it isn't already present and returns
+   * the corresponding index.
+   * @param path The path to be added. It will be normalized.
+   * @return The index corresponding to the added path.
+   */
   std::size_t addPath(std::string& path);
 
+  /**
+   * @brief Adds a normalized path to the graph if it isn't already present and
+   * returns the corresponding index.
+   * @param path The normalized path to be added.
+   * @return The index corresponding to the added path.
+   */
   std::size_t addNormalizedPath(std::string_view path);
 
+  /**
+   * @brief Finds the index of the specified path if it exists.
+   * @param path The path to be found. It will be normalized.
+   * @return The index of the path if found, otherwise std::nullopt.
+   */
   std::optional<std::size_t> findPath(std::string& path) const;
+
+  /**
+   * @brief Finds the index of the specified normalized path if it exists.
+   * @param path The normalized path to be found.
+   * @return The index of the path if found, otherwise std::nullopt.
+   */
   std::optional<std::size_t> findNormalizedPath(std::string_view path) const;
 
+  /**
+   * @brief Adds a default node to the graph.
+   * @return The index of the default node.
+   */
   std::size_t addDefault();
 
+  /**
+   * @brief Adds an edge between the specified input and output nodes.
+   * @param in The index of the input node.
+   * @param out The index of the output node.
+   */
   void addEdge(std::size_t in, std::size_t out);
 
+  /**
+   * @brief Checks if the specified path index is the default node.
+   * @param pathIndex The index of the path to check.
+   * @return True if the path index is the default node, otherwise false.
+   */
   bool isDefault(std::size_t pathIndex) const;
+
+  /**
+   * @brief Gets the index of the default node.
+   * @return The index of the default node.
+   */
   std::size_t defaultIndex() const;
 
+  /**
+   * @brief Gets the path corresponding to the specified path index.
+   * @param pathIndex The index of the path.
+   * @return The path corresponding to the specified index.
+   */
   std::string_view path(std::size_t pathIndex) const;
+
+  /**
+   * @brief Gets the set of output nodes for the specified path index.
+   * @param pathIndex The index of the path.
+   * @return The set of output nodes.
+   */
   const std::set<std::size_t>& out(std::size_t pathIndex) const;
+
+  /**
+   * @brief Gets the set of input nodes for the specified path index.
+   * @param pathIndex The index of the path.
+   * @return The set of input nodes.
+   */
   const std::set<std::size_t>& in(std::size_t pathIndex) const;
 
+  /**
+   * @brief Gets the index of the specified path.
+   * @param path The path to be found.
+   * @return The index of the path.
+   */
   std::size_t getPath(std::string_view path) const;
 
+  /**
+   * @brief Gets the number of nodes in the graph.
+   * @return The number of nodes.
+   */
   std::size_t size() const;
 };
 

--- a/src/logreader.h
+++ b/src/logreader.h
@@ -32,6 +32,14 @@
 
 namespace trimja {
 
+/**
+ * @struct LogEntry
+ * @brief Represents a single log entry.
+ *
+ * This structure holds information about a single log entry, including
+ * start and end times, modification time, output path, and the build hash
+ * value.
+ */
 struct LogEntry {
   std::chrono::duration<std::int32_t, std::milli> startTime;
   std::chrono::duration<std::int32_t, std::milli> endTime;
@@ -40,13 +48,31 @@ struct LogEntry {
   std::uint64_t hash;
 };
 
+/**
+ * @class LogReader
+ * @brief Reads and parses log entries from an input stream.
+ *
+ * The LogReader class provides functionality to read and parse log entries
+ * from a given input stream. It supports iteration over the log entries.
+ */
 class LogReader {
   std::istream* m_logs;
   std::string m_nextLine;
 
  public:
+  /**
+   * @struct sentinel
+   * @brief Sentinel type for the end of the iterator range.
+   */
   struct sentinel {};
 
+  /**
+   * @class iterator
+   * @brief Iterator for traversing log entries.
+   *
+   * The iterator class provides functionality to traverse log entries
+   * read by the LogReader.
+   */
   class iterator {
     LogReader* m_reader;
     LogEntry m_entry;
@@ -55,22 +81,72 @@ class LogReader {
     using difference_type = std::ptrdiff_t;
     using value_type = LogEntry;
 
+    /**
+     * @brief Constructs an iterator for the given LogReader.
+     * @param reader Pointer to the LogReader.
+     */
     iterator(LogReader* reader);
 
+    /**
+     * @brief Dereferences the iterator to access the current log entry.
+     * @return Reference to the current log entry.
+     */
     const LogEntry& operator*() const;
 
+    /**
+     * @brief Advances the iterator to the next log entry.
+     * @return Reference to the iterator.
+     */
     iterator& operator++();
+
+    /**
+     * @brief Advances the iterator to the next log entry.
+     */
     void operator++(int);
+
+    /**
+     * @brief Compares the iterator with a sentinel for equality.
+     * @param iter The iterator to compare.
+     * @param s The sentinel to compare.
+     * @return Return whether the iterator has read past the end of the file.
+     */
     friend bool operator==(const iterator& iter, sentinel s);
+
+    /**
+     * @brief Compares the iterator with a sentinel for inequality.
+     * @param iter The iterator to compare.
+     * @param s The sentinel to compare.
+     * @return Return whether the iterator points to a valid entry, i.e. not
+     * past the end of the file.
+     */
     friend bool operator!=(const iterator& iter, sentinel s);
   };
 
  public:
+  /**
+   * @brief Constructs a LogReader with the given input stream.
+   * @param logs The input stream to read log entries from.
+   */
   explicit LogReader(std::istream& logs);
 
+  /**
+   * @brief Reads the next log entry from the input stream.
+   * @param output Pointer to the LogEntry to store the read data.
+   * @return Return true if an entry was successfully read and false if we are
+   * at the end of the file.
+   */
   bool read(LogEntry* output);
 
+  /**
+   * @brief Returns an iterator to the beginning of the log entries.
+   * @return An iterator to the beginning of the log entries.
+   */
   iterator begin();
+
+  /**
+   * @brief Returns a sentinel representing the end of the log entries.
+   * @return A sentinel representing the end of the log entries.
+   */
   sentinel end();
 };
 

--- a/src/manifestparser.h
+++ b/src/manifestparser.h
@@ -36,6 +36,10 @@ namespace trimja {
 
 namespace detail {
 
+/**
+ * @struct BaseReader
+ * @brief Base class for reading tokens from a Ninja build file.
+ */
 struct BaseReader {
  protected:
   Lexer* m_lexer;
@@ -46,6 +50,10 @@ struct BaseReader {
   const char* position() const;
 };
 
+/**
+ * @struct BaseReaderWithStart
+ * @brief Base class for reading tokens with a start position.
+ */
 struct BaseReaderWithStart : public BaseReader {
  private:
   const char* m_start;
@@ -58,6 +66,10 @@ struct BaseReaderWithStart : public BaseReader {
 
 }  // namespace detail
 
+/**
+ * @class VariableReader
+ * @brief Class for reading variable definitions in a Ninja build file.
+ */
 class VariableReader : public detail::BaseReaderWithStart {
  public:
   using detail::BaseReaderWithStart::BaseReaderWithStart;
@@ -65,6 +77,11 @@ class VariableReader : public detail::BaseReaderWithStart {
   const EvalString& value();
 };
 
+/**
+ * @class LetRangeReader
+ * @brief Class for reading a range of variable definitions in a Ninja build
+ * file.
+ */
 class LetRangeReader : public detail::BaseReaderWithStart {
  public:
   class sentinel {};
@@ -89,6 +106,10 @@ class LetRangeReader : public detail::BaseReaderWithStart {
   sentinel end() const;
 };
 
+/**
+ * @class PathRangeReader
+ * @brief Class for reading a range of paths in a Ninja build file.
+ */
 class PathRangeReader : public detail::BaseReader {
  public:
   class sentinel {};
@@ -125,6 +146,10 @@ class PathRangeReader : public detail::BaseReader {
   sentinel end() const;
 };
 
+/**
+ * @class PoolReader
+ * @brief Class for reading pool definitions in a Ninja build file.
+ */
 class PoolReader : public detail::BaseReaderWithStart {
  public:
   using detail::BaseReaderWithStart::BaseReaderWithStart;
@@ -132,6 +157,10 @@ class PoolReader : public detail::BaseReaderWithStart {
   LetRangeReader variables();
 };
 
+/**
+ * @class BuildReader
+ * @brief Class for reading build statements in a Ninja build file.
+ */
 class BuildReader : public detail::BaseReaderWithStart {
  public:
   using detail::BaseReaderWithStart::BaseReaderWithStart;
@@ -145,6 +174,10 @@ class BuildReader : public detail::BaseReaderWithStart {
   LetRangeReader variables();
 };
 
+/**
+ * @class RuleReader
+ * @brief Class for reading rule definitions in a Ninja build file.
+ */
 class RuleReader : public detail::BaseReaderWithStart {
  public:
   using detail::BaseReaderWithStart::BaseReaderWithStart;
@@ -152,12 +185,20 @@ class RuleReader : public detail::BaseReaderWithStart {
   LetRangeReader variables();
 };
 
+/**
+ * @class DefaultReader
+ * @brief Class for reading default statements in a Ninja build file.
+ */
 class DefaultReader : public detail::BaseReaderWithStart {
  public:
   using detail::BaseReaderWithStart::BaseReaderWithStart;
   PathRangeReader paths();
 };
 
+/**
+ * @class IncludeReader
+ * @brief Class for reading include statements in a Ninja build file.
+ */
 class IncludeReader : public detail::BaseReaderWithStart {
  public:
   using detail::BaseReaderWithStart::BaseReaderWithStart;
@@ -168,6 +209,10 @@ class IncludeReader : public detail::BaseReaderWithStart {
   const std::filesystem::path& parent() const;
 };
 
+/**
+ * @class SubninjaReader
+ * @brief Class for reading subninja statements in a Ninja build file.
+ */
 class SubninjaReader : public detail::BaseReaderWithStart {
  public:
   using detail::BaseReaderWithStart::BaseReaderWithStart;
@@ -177,6 +222,10 @@ class SubninjaReader : public detail::BaseReaderWithStart {
   const std::filesystem::path& parent() const;
 };
 
+/**
+ * @class ManifestReader
+ * @brief Class for parsing a Ninja build file.
+ */
 class ManifestReader {
   Lexer m_lexer;
   EvalString m_storage;

--- a/src/murmur_hash.h
+++ b/src/murmur_hash.h
@@ -28,7 +28,18 @@
 
 namespace trimja {
 
+/**
+ * @struct murmur_hash
+ * @brief Provides a static method to compute the MurmurHash.
+ */
 struct murmur_hash {
+  /**
+   * @brief Computes the MurmurHash for the given key.
+   *
+   * @param key Pointer to the data to hash.
+   * @param length Length of the data in bytes.
+   * @return 64-bit hash value.
+   */
   static std::uint64_t hash(const void* key, std::size_t length);
 };
 

--- a/src/ninja_clock.h
+++ b/src/ninja_clock.h
@@ -27,9 +27,13 @@
 
 namespace trimja {
 
-// `ninja_clock` represents the on-disk time saved within the `.ninja_deps`
-// file.  `ninja_clock::time_point` is guaranteed to be the same layout
-// as the last modified time saved in this file.
+/**
+ * @struct ninja_clock
+ * @brief Represents the on-disk time saved within the .ninja_deps file.
+ *
+ * ninja_clock::time_point is guaranteed to be the same layout
+ * as the last modified time saved in this file.
+ */
 struct ninja_clock {
   using rep = std::uint64_t;
   using period = std::nano;
@@ -37,9 +41,21 @@ struct ninja_clock {
   using time_point = std::chrono::time_point<ninja_clock>;
   static const bool is_steady = false;
 
+  /**
+   * @brief Converts a file_clock::time_point to a ninja_clock::time_point.
+   *
+   * @param t The file_clock::time_point to convert.
+   * @return The corresponding ninja_clock::time_point.
+   */
   static trimja::ninja_clock::time_point from_file_clock(
       std::chrono::file_clock::time_point t);
 
+  /**
+   * @brief Converts a ninja_clock::time_point to a file_clock::time_point.
+   *
+   * @param t The ninja_clock::time_point to convert.
+   * @return The corresponding file_clock::time_point.
+   */
   static std::chrono::file_clock::time_point to_file_clock(
       trimja::ninja_clock::time_point t);
 };
@@ -51,17 +67,37 @@ struct ninja_clock {
 namespace std {
 namespace chrono {
 
+/**
+ * @struct clock_time_conversion
+ * @brief Specialization for converting between trimja::ninja_clock and file_clock.
+ */
 template <>
 struct clock_time_conversion<trimja::ninja_clock, file_clock> {
+  /**
+   * @brief Converts a file_clock::time_point to a ninja_clock::time_point.
+   * 
+   * @param t The file_clock::time_point to convert.
+   * @return The corresponding ninja_clock::time_point.
+   */
   trimja::ninja_clock::time_point operator()(file_clock::time_point t);
 };
 
+/**
+ * @struct clock_time_conversion
+ * @brief Specialization for converting between file_clock and trimja::ninja_clock.
+ */
 template <>
 struct clock_time_conversion<file_clock, trimja::ninja_clock> {
+  /**
+   * @brief Converts a ninja_clock::time_point to a file_clock::time_point.
+   * 
+   * @param t The ninja_clock::time_point to convert.
+   * @return The corresponding file_clock::time_point.
+   */
   file_clock::time_point operator()(trimja::ninja_clock::time_point t);
 };
 
 }  // namespace chrono
 }  // namespace std
 #endif
-#endif
+#endif  // TRIMJA_NINJA_CLOCK

--- a/src/rule.h
+++ b/src/rule.h
@@ -33,8 +33,15 @@ struct EvalString;
 
 namespace trimja {
 
+/**
+ * @class Rule
+ * @brief Represents a build rule in the Ninja build system.
+ */
 class Rule {
  public:
+  /**
+   * @brief List of reserved variable names in a rule.
+   */
   inline static const std::string_view reserved[] = {
       "command",          "depfile", "dyndep", "description", "deps",
       "generator",        "pool",    "restat", "rspfile",     "rspfile_content",
@@ -44,20 +51,49 @@ class Rule {
  private:
   std::string_view m_name;
 
-  // The `std::string_view*` points to an element of `reserved`
+  // The std::string_view* points to an element of reserved
   std::vector<std::pair<const std::string_view*, EvalString>> m_bindings;
 
  public:
+  /**
+   * @brief Gets the lookup index for a given variable name.
+   *
+   * @param varName The variable name to look up.
+   * @return The index of the variable name in the reserved list.
+   */
   static std::size_t getLookupIndex(std::string_view varName);
 
-  // Create a `Rule` having the specified `name`. The string pointed to by
-  // `name` MUST live longer than this object.
+  /**
+   * @brief Constructs a Rule with the given name.
+   *
+   * @param name The name of the rule. The lifetime of the string pointed to by
+   * name must outlive this object.
+   */
   explicit Rule(std::string_view name);
 
+  /**
+   * @brief Gets the name of the rule.
+   *
+   * @return The name of the rule.
+   */
   std::string_view name() const;
 
+  /**
+   * @brief Adds a variable and its value to the rule.
+   *
+   * @param varName The name of the variable.
+   * @param value The value of the variable.
+   * @return True if the variable was added successfully, false otherwise.
+   */
   bool add(std::string_view varName, EvalString value);
 
+  /**
+   * @brief Looks up the value of a variable in the rule.
+   *
+   * @param varName The name of the variable to look up.
+   * @return A pointer to the EvalString value of the variable, or nullptr if
+   * not found.
+   */
   const EvalString* lookupVar(std::string_view varName) const;
 };
 

--- a/src/trimutil.cpp
+++ b/src/trimutil.cpp
@@ -243,7 +243,7 @@ struct BuildContext {
 
     for (VariableReader v : r.variables()) {
       const std::string_view name = v.name();
-      evaluate(scope.clearValue(name), v.value(), scope);
+      evaluate(scope.resetValue(name), v.value(), scope);
     }
 
     const std::size_t partsIndex = parts.size();
@@ -341,7 +341,7 @@ struct BuildContext {
 
   void operator()(VariableReader& r) {
     std::string_view name = r.name();
-    evaluate(fileScope.clearValue(name), r.value(), fileScope);
+    evaluate(fileScope.resetValue(name), r.value(), fileScope);
     parts.emplace_back(r.start(), r.bytesParsed());
   }
 

--- a/src/trimutil.h
+++ b/src/trimutil.h
@@ -29,7 +29,20 @@
 
 namespace trimja {
 
+/**
+ * @struct TrimUtil
+ * @brief Utility to trim a Ninja build file based on a list of affected files.
+ */
 struct TrimUtil {
+  /**
+   * @brief Trims the given Ninja build file based on the affected files.
+   *
+   * @param output The output stream to write the trimmed Ninja file to.
+   * @param ninjaFile The path to the original Ninja build file.
+   * @param ninjaFileContents The contents of the original Ninja build file.
+   * @param affected The input stream containing the list of affected files.
+   * @param explain If true, prints to stderr why each build command was kept.
+   */
   static void trim(std::ostream& output,
                    const std::filesystem::path& ninjaFile,
                    const std::string& ninjaFileContents,


### PR DESCRIPTION
Add a reasonable set of documentation to all header files.

Rename the `clearValue` method in scopes to `resetValue` as it describes the behaviour more closely.