### PR TITLE
Release v0.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.26.3)
-project(trimja VERSION 0.3.0)
+project(trimja VERSION 0.4.0)
 enable_testing()
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
  * Fix `$in` variable containing order-only dependencies
  * Do not include outputs if only their order-only dependencies have been affected