### PR TITLE
Release v0.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.26.3)
-project(trimja VERSION 0.4.0)
+project(trimja VERSION 0.5.0)
 enable_testing()
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
  * Check the absolute path of affected files from the current working directory instead of the path of the ninja build file.  In most situations we are building these affected files from the root of the project rather than whatever subfolder the ninja build file resides.