### PR TITLE
Release v0.5.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.26.3)
-project(trimja VERSION 0.5.1)
+project(trimja VERSION 0.5.2)
 enable_testing()
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
  * Fix `default` statements not being printed out correctly when all their inputs are not marked as affected.