### PR TITLE
Remove `fixed_string` temporaries

### DIFF
--- a/src/basicscope.cpp
+++ b/src/basicscope.cpp
@@ -30,19 +30,17 @@ std::string_view BasicScope::set(std::string_view key, std::string&& value) {
   // By design to avoid accidental copies, `fixed_string` does not have a copy
   // constructor so we cannot use `operator[]`.  Instead we can use `emplace` to
   // achieve basically the same performance.
-  return m_variables.emplace(fixed_string::create(key), "").first->second =
-             std::move(value);
+  return m_variables.try_emplace(key, std::move(value)).first->second;
 }
 
 std::string& BasicScope::resetValue(std::string_view key) {
-  std::string& value =
-      m_variables.emplace(fixed_string::create(key), "").first->second;
+  std::string& value = m_variables.try_emplace(key, "").first->second;
   value.clear();
   return value;
 }
 
 bool BasicScope::appendValue(std::string& output, std::string_view name) const {
-  const auto it = m_variables.find(fixed_string::make_temp(name));
+  const auto it = m_variables.find(name);
   if (it == m_variables.end()) {
     return false;
   } else {

--- a/src/basicscope.h
+++ b/src/basicscope.h
@@ -37,7 +37,10 @@ namespace trimja {
  * @brief Manages a scope of variables for evaluation and substitution.
  */
 class BasicScope {
-  boost::unordered_flat_map<fixed_string, std::string> m_variables;
+  boost::unordered_flat_map<fixed_string,
+                            std::string,
+                            std::hash<trimja::fixed_string>>
+      m_variables;
 
  public:
   /**

--- a/src/graph.h
+++ b/src/graph.h
@@ -43,17 +43,23 @@ namespace trimja {
  */
 class Graph {
   struct PathHash {
+    using is_transparent = void;
+
     // We need `PathHash` to have some size, otherwise we hit a compilation
     // issue with `boost::unordered_flat_map`.
     void* _;
     std::size_t operator()(const fixed_string& v) const;
+    std::size_t operator()(std::string_view v) const;
   };
 
   struct PathEqual {
+    using is_transparent = void;
+
     // We need `PathEqual` to have some size, otherwise we hit a compilation
     // issue with `boost::unordered_flat_map`.
     void* _;
     bool operator()(const fixed_string& left, const fixed_string& right) const;
+    bool operator()(std::string_view left, const fixed_string& right) const;
   };
 
  private:

--- a/src/trimutil.cpp
+++ b/src/trimutil.cpp
@@ -140,8 +140,7 @@ struct BuildContext {
       const std::size_t partsIndex = parts.size();
       const std::size_t ruleIndex = rules.size();
       parts.emplace_back("");
-      const auto ruleIt =
-          ruleLookup.emplace(fixed_string::create(builtIn), ruleIndex).first;
+      const auto ruleIt = ruleLookup.try_emplace(builtIn, ruleIndex).first;
       rules.emplace_back(ruleIt->first, partsIndex);
     }
     assert(rules[BuildContext::phonyIndex].first.name() == "phony");
@@ -210,7 +209,7 @@ struct BuildContext {
     std::string_view ruleName = r.name();
 
     const std::size_t ruleIndex = [&] {
-      const auto ruleIt = ruleLookup.find(fixed_string::make_temp(ruleName));
+      const auto ruleIt = ruleLookup.find(ruleName);
       if (ruleIt == ruleLookup.end()) {
         throw std::runtime_error("Unable to find " + std::string(ruleName) +
                                  " rule");
@@ -310,8 +309,7 @@ struct BuildContext {
   void operator()(RuleReader& r) {
     std::string_view name = r.name();
     const std::size_t ruleIndex = rules.size();
-    const auto [ruleIt, inserted] =
-        ruleLookup.emplace(fixed_string::create(name), ruleIndex);
+    const auto [ruleIt, inserted] = ruleLookup.try_emplace(name, ruleIndex);
     if (!inserted) {
       std::string msg;
       msg += "Duplicate rule '";


### PR DESCRIPTION
We can go back to using `is_transparent` and heterogenous lookup since `boost::unordered_flat_map` supports it.  Previously we had to remove it when supporting older compiler versions.

This removes a bunch of temporary copies (that probably could have been avoided) and cleans up the code a lot.  The constructor taking a `std::string_view` is marked as `explicit` so we do not accidentally create `fixed_string`s if we pass a `std::string_view` into `find()` and haven't used the right hash and equality predicate that support `is_transparent`.