### PR TITLE
Simplify `EdgeScope`

### DIFF
--- a/src/edgescope.cpp
+++ b/src/edgescope.cpp
@@ -25,12 +25,11 @@
 #include <ninja/util.h>
 
 namespace trimja {
-
 namespace detail {
 
-void EdgeScopeBase::appendPaths(std::string& output,
-                                std::span<const std::string> paths,
-                                const char separator) {
+void appendPaths(std::string& output,
+                 std::span<const std::string> paths,
+                 const char separator) {
   auto it = paths.begin();
   const auto end = paths.end();
   if (it == end) {
@@ -45,18 +44,6 @@ void EdgeScopeBase::appendPaths(std::string& output,
   }
 }
 
-EdgeScopeBase::EdgeScopeBase(const Rule& rule,
-                             std::span<const std::string> ins,
-                             std::span<const std::string> outs)
-    : m_ins(ins), m_outs(outs), m_local(), m_rule(rule) {}
-
-std::string_view EdgeScopeBase::set(std::string_view key, std::string&& value) {
-  return m_local.set(key, std::move(value));
-}
-
-std::string& EdgeScopeBase::resetValue(std::string_view key) {
-  return m_local.resetValue(key);
-}
-
 }  // namespace detail
+
 }  // namespace trimja


### PR DESCRIPTION
Usually it is good practice to factor out the non-template parts of templated class into a non-template base to reduce compilation times. However, `EdgeScope` is only ever instantiated once and this extra compication isn't worth the initial complexity.

Keep `appendPaths` defined in the source file so we don't have to include `<ninja/util.h>` in `edgescope.h`.