### PR TITLE
Remove roundtrip to `std::filesystem::path`

### DIFF
--- a/src/logreader.cpp
+++ b/src/logreader.cpp
@@ -108,7 +108,7 @@ bool LogReader::read(LogEntry* output) {
         ninja_clock::time_point{ninja_clock::duration{ticks}});
   }
 
-  output->output = parts[3];
+  output->out = parts[3];
   std::from_chars(parts[4].data(), parts[4].data() + parts[4].size(),
                   output->hash, 16);
   return true;

--- a/src/logreader.h
+++ b/src/logreader.h
@@ -25,10 +25,10 @@
 
 #include <chrono>
 #include <cstddef>
-#include <filesystem>
 #include <iosfwd>
 #include <iterator>
 #include <string>
+#include <string_view>
 
 namespace trimja {
 
@@ -44,7 +44,7 @@ struct LogEntry {
   std::chrono::duration<std::int32_t, std::milli> startTime;
   std::chrono::duration<std::int32_t, std::milli> endTime;
   std::chrono::file_clock::time_point mtime;
-  std::filesystem::path output;
+  std::string_view out;
   std::uint64_t hash;
 };
 

--- a/src/trimutil.cpp
+++ b/src/trimutil.cpp
@@ -527,7 +527,7 @@ void parseLogFile(const std::filesystem::path& ninjaLog,
   for (const LogEntry& entry : LogReader(deps)) {
     // Entries in `.ninja_log` are already normalized when written
     const std::optional<std::size_t> index =
-        graph.findNormalizedPath(entry.output.string());
+        graph.findNormalizedPath(entry.out);
     if (!index) {
       // If we don't have the path then it was since removed from the ninja
       // build file


### PR DESCRIPTION
Use the allocation instrumentor to take a look at paths that allocate a lot and here we have an unnecessary allocation when constructing a `std::filesystem::path` and then another one converting back to a `std::string`.