### PR TITLE
Support subninja fully

### DIFF
--- a/src/rule.cpp
+++ b/src/rule.cpp
@@ -26,7 +26,7 @@
 
 namespace trimja {
 
-Rule::Rule(std::string_view name) : m_name(name), m_bindings() {}
+Rule::Rule() = default;
 
 std::size_t Rule::getLookupIndex(std::string_view varName) {
   return std::find(std::begin(reserved), std::end(reserved), varName) -
@@ -62,10 +62,6 @@ const EvalString* Rule::lookupVar(std::string_view varName) const {
         return *binding.first == varName;
       });
   return it != m_bindings.cend() ? &it->second : nullptr;
-}
-
-std::string_view Rule::name() const {
-  return m_name;
 }
 
 }  // namespace trimja

--- a/src/rule.h
+++ b/src/rule.h
@@ -47,8 +47,6 @@ class Rule {
   };
 
  private:
-  std::string_view m_name;
-
   // The std::string_view* points to an element of reserved
   std::vector<std::pair<const std::string_view*, EvalString>> m_bindings;
 
@@ -62,19 +60,9 @@ class Rule {
   static std::size_t getLookupIndex(std::string_view varName);
 
   /**
-   * @brief Constructs a Rule with the given name.
-   *
-   * @param name The name of the rule. The lifetime of the string pointed to by
-   * name must outlive this object.
+   * @brief Constructs a Rule
    */
-  explicit Rule(std::string_view name);
-
-  /**
-   * @brief Gets the name of the rule.
-   *
-   * @return The name of the rule.
-   */
-  std::string_view name() const;
+  Rule();
 
   /**
    * @brief Adds a variable and its value to the rule.

--- a/tests/subninja/build.ninja
+++ b/tests/subninja/build.ninja
@@ -1,6 +1,9 @@
 rule copy
-  command = ninja --version $in -> $out $var
+  command = ninja --version copy.build.ninja $in -> $out $var
 file1 = in1
 var = 3
 subninja other.ninja
 build out3: copy in3
+rule tar
+  command = ninja --version tar.build.ninja $in -> $out
+build out4: tar in4

--- a/tests/subninja/changed.txt
+++ b/tests/subninja/changed.txt
@@ -1,3 +1,4 @@
 in1
 in2
 in3
+in4

--- a/tests/subninja/expected.ninja
+++ b/tests/subninja/expected.ninja
@@ -1,13 +1,16 @@
 rule copy
-  command = ninja --version $in -> $out $var
+  command = ninja --version copy.build.ninja $in -> $out $var
 file1 = in1
 var = 3
 var = 4
 file2 = in2
 build out1: copy $file1
 rule copy2
-  command = ninja --version copy2 $in -> $out $var
+  command = ninja --version copy.other.ninja $in -> $out $var
 build out2: copy2 $file2
 var = 3
 file2 =
 build out3: copy in3
+rule tar2
+  command = ninja --version tar.build.ninja $in -> $out
+build out4: tar2 in4

--- a/tests/subninja/other.ninja
+++ b/tests/subninja/other.ninja
@@ -1,6 +1,8 @@
 var = 4
 file2 = in2
 build out1: copy $file1
-rule copy2
-  command = ninja --version copy2 $in -> $out $var
-build out2: copy2 $file2
+rule copy
+  command = ninja --version copy.other.ninja $in -> $out $var
+build out2: copy $file2
+rule tar
+  command = ninja --version tar.other.ninja $in -> $out


### PR DESCRIPTION
Handle the situation when we have rules in subninja files that shadow parent rules (or vice versa).  Keep a running count of how many times a rule `foo` has been seen and write `fooN` for subsequent new rules where `N` is an incrementing number starting at 2.