### PR TITLE
Print allocations on `--builddir`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,16 +196,27 @@ set_tests_properties(
 # --memory
 if(WIN32)
     add_test(
-        NAME trimja.snapshot.--memory
+        NAME trimja.--memory
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests/passthrough/
         COMMAND trimja
         --memory=3
-        --expected expected.ninja
         --affected changed.txt
     )
     set_tests_properties(
-        trimja.snapshot.--memory
+        trimja.--memory
         PROPERTIES FIXTURES_REQUIRED trimja.snapshot.passthrough.fixture
+    )
+
+    add_test(
+        NAME trimja.--memory2
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests/builddir/
+        COMMAND trimja
+        --memory=3
+        --builddir
+    )
+    set_tests_properties(
+        trimja.--memory2
+        PROPERTIES FIXTURES_REQUIRED trimja.snapshot.builddir.fixture
     )
 endif()
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Options:
   -w, --write               overwrite input ninja build file
   --explain                 print why each part of the build file was kept
   --builddir                print the $builddir variable relative to the cwd
+  --memory=N                print memory stats and top N allocating functions
   -h, --help                print help
   -v, --version             print trimja version
 


### PR DESCRIPTION
Standardize how we exit `main` through the `leave` function so that we
can make sure to print out our memory stats on every path.  To make sure
we call `leave` we can decorate `main` as `[[noreturn]]`.