### PR TITLE
Add `--cpu-stats` flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
     src/allocationprofiler.cpp
     src/basicscope.cpp
     src/builddirutil.cpp
+    src/cpuprofiler.cpp
     src/depsreader.cpp
     src/edgescope.cpp
     src/evalstring.cpp
@@ -193,32 +194,45 @@ set_tests_properties(
     PROPERTIES FIXTURES_REQUIRED trimja.snapshot.simple.fixture
 )
 
-# --memory
+# --memory-stats
 if(WIN32)
     add_test(
-        NAME trimja.--memory
+        NAME trimja.--memory-stats
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests/passthrough/
         COMMAND trimja
-        --memory=3
+        --memory-stats=3
         --affected changed.txt
     )
     set_tests_properties(
-        trimja.--memory
+        trimja.--memory-stats
         PROPERTIES FIXTURES_REQUIRED trimja.snapshot.passthrough.fixture
     )
 
     add_test(
-        NAME trimja.--memory2
+        NAME trimja.--memory-stats2
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests/builddir/
         COMMAND trimja
-        --memory=3
+        --memory-stats=3
         --builddir
     )
     set_tests_properties(
-        trimja.--memory2
+        trimja.--memory-stats2
         PROPERTIES FIXTURES_REQUIRED trimja.snapshot.builddir.fixture
     )
 endif()
+
+# --cpu-stats
+add_test(
+    NAME trimja.--cpu-stats
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests/passthrough/
+    COMMAND trimja
+    --cpu-stats
+    --affected changed.txt
+)
+set_tests_properties(
+    trimja.--cpu-stats
+    PROPERTIES FIXTURES_REQUIRED trimja.snapshot.passthrough.fixture
+)
 
 # --builddir
 add_test(

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Options:
   -w, --write               overwrite input ninja build file
   --explain                 print why each part of the build file was kept
   --builddir                print the $builddir variable relative to the cwd
-  --memory=N                print memory stats and top N allocating functions
+  --memory-stats=N          print memory stats and top N allocating functions
+  --cpu-stats               print timing stats
   -h, --help                print help
   -v, --version             print trimja version
 

--- a/src/builddirutil.cpp
+++ b/src/builddirutil.cpp
@@ -23,6 +23,7 @@
 #include "builddirutil.h"
 
 #include "basicscope.h"
+#include "cpuprofiler.h"
 #include "manifestparser.h"
 
 #include <fstream>
@@ -119,7 +120,10 @@ std::filesystem::path BuildDirUtil::builddir(
     const std::filesystem::path& ninjaFile,
     const std::string& ninjaFileContents) {
   BuildDirContext ctx;
-  ctx.parse(ninjaFile, ninjaFileContents);
+  {
+    const Timer t = CPUProfiler::start(".ninja parse");
+    ctx.parse(ninjaFile, ninjaFileContents);
+  }
   std::string builddir;
   ctx.fileScope.appendValue(builddir, "builddir");
   return std::filesystem::path(ninjaFile).remove_filename() / builddir;

--- a/src/cpuprofiler.cpp
+++ b/src/cpuprofiler.cpp
@@ -1,0 +1,77 @@
+// MIT License
+//
+// Copyright (c) 2024 Elliot Goodrich
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "cpuprofiler.h"
+
+#include <list>
+#include <ostream>
+#include <string>
+
+namespace trimja {
+
+namespace {
+
+std::list<std::pair<std::string, std::chrono::steady_clock::duration>>
+    g_cpuMetrics;
+bool g_cpuEnabled = false;
+
+}  // namespace
+
+Timer::Timer(std::chrono::steady_clock::duration* output) : m_output{output} {
+  if (m_output) {
+    m_start = std::chrono::steady_clock::now();
+  }
+}
+
+Timer::~Timer() {
+  stop();
+}
+
+void Timer::stop() {
+  if (m_output) {
+    *m_output = std::chrono::steady_clock::now() - m_start;
+  }
+}
+
+void CPUProfiler::enable() {
+  g_cpuEnabled = true;
+}
+
+bool CPUProfiler::isEnabled() {
+  return g_cpuEnabled;
+}
+
+Timer CPUProfiler::start(std::string_view name) {
+  return Timer{g_cpuEnabled ? &g_cpuMetrics.emplace_back(name, 0).second
+                            : nullptr};
+}
+
+void CPUProfiler::print(std::ostream& out) {
+  for (const auto& [name, duration] : g_cpuMetrics) {
+    out << name << ": "
+        << std::chrono::duration_cast<std::chrono::microseconds>(duration)
+               .count()
+        << "us\n";
+  }
+}
+
+}  // namespace trimja

--- a/src/cpuprofiler.h
+++ b/src/cpuprofiler.h
@@ -1,0 +1,92 @@
+// MIT License
+//
+// Copyright (c) 2024 Elliot Goodrich
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TRIMJA_CPUPROFILER
+#define TRIMJA_CPUPROFILER
+
+#include <chrono>
+#include <iosfwd>
+#include <string_view>
+
+namespace trimja {
+
+/**
+ * @brief Timer class to measure the duration of code execution.
+ */
+struct Timer {
+  std::chrono::steady_clock::duration* m_output;
+  std::chrono::steady_clock::time_point m_start;
+
+  /**
+   * @brief Constructs a Timer and optionally starts timing.
+   *
+   * @param output Optional pointer to a duration object where the elapsed time
+   * will be stored if it is not nullptr.
+   */
+  Timer(std::chrono::steady_clock::duration* output);
+
+  /**
+   * @brief Destroys the Timer and stops timing if not already stopped.
+   */
+  ~Timer();
+
+  /**
+   * @brief Stops the timer and writes the elapsed time.
+   */
+  void stop();
+};
+
+/**
+ * @brief Utility to enable and manage CPU profiling.
+ */
+struct CPUProfiler {
+  /**
+   * @brief Enables the CPU profiler.
+   */
+  static void enable();
+
+  /**
+   * @brief Checks if the CPU profiler is enabled.
+   *
+   * @return Whether the profiler is enabled.
+   */
+  static bool isEnabled();
+
+  /**
+   * @brief Starts a new timer for profiling a specific code section.
+   *
+   * @param name The name of the code section being profiled.
+   * @return A Timer object that measures the duration of the code section.
+   */
+  static Timer start(std::string_view name);
+
+  /**
+   * @brief Prints the profiling results to the provided output stream.
+   *
+   * @param out The output stream to print the profiling results.
+   */
+  static void print(std::ostream& out);
+};
+
+}  // namespace trimja
+
+#endif


### PR DESCRIPTION
Add a `--cpu-stats` flag that will print out timing information for any interesting and critical parts of the code for future investigation. This is similar to Ninja's `-d stats` mode.

Rename `--memory` to `--memory-stats` as this is a better name that better conveys its meaning.