### PR TITLE
Small tidy of `std::pair` creation

### DIFF
--- a/src/evalstring.cpp
+++ b/src/evalstring.cpp
@@ -73,9 +73,8 @@ std::pair<std::string_view, EvalString::TokenType>
 EvalString::const_iterator::operator*() const {
   Offset length;
   std::copy_n(m_pos, sizeof(length), reinterpret_cast<char*>(&length));
-  return std::make_pair(
-      std::string_view{m_pos + sizeof(length), clearLeadingBit(length)},
-      hasLeadingBit(length) ? TokenType::Variable : TokenType::Text);
+  return {{m_pos + sizeof(length), clearLeadingBit(length)},
+          static_cast<TokenType>(hasLeadingBit(length))};
 }
 
 EvalString::const_iterator& EvalString::const_iterator::operator++() {

--- a/src/evalstring.h
+++ b/src/evalstring.h
@@ -50,8 +50,8 @@ class EvalString {
    * @brief Enum to represent the type of token.
    */
   enum class TokenType {
-    Text,     ///< Represents a text token.
-    Variable  ///< Represents a variable token.
+    Text = 0,      ///< Represents a text token.
+    Variable = 1,  ///< Represents a variable token.
   };
 
   /**


### PR DESCRIPTION
Make it very obvious to the compiler that we don't need a conditional here and that we can construct the `std::pair` directly.  Based on profiling, MSVC is struggling with this and is causing a ~1% overhead.