### PR TITLE
Avoid syncing with stdio

### DIFF
--- a/src/trimja.m.cpp
+++ b/src/trimja.m.cpp
@@ -134,6 +134,8 @@ bool instrumentMemory = false;
   // avoids the overhead of destructing objects on the stack.
   using namespace trimja;
 
+  std::ios_base::sync_with_stdio(false);
+
   struct StdIn {};
   std::variant<std::monostate, StdIn, std::filesystem::path> affectedFile;
 


### PR DESCRIPTION
When writing to `std::cout` and `std::cerr`, and reading from `std::cin` we sync with C standard stream by default, which has overhead.  As we don't use C standard streams we can avoid this and gain a bit of performance.