### PR TITLE
Skip destructors within `TrimUtil`

### DIFF
--- a/src/trimja.m.cpp
+++ b/src/trimja.m.cpp
@@ -315,7 +315,11 @@ bool instrumentMemory = false;
         }
       },
       outputFile);
-  TrimUtil::trim(output, ninjaFile, ninjaFileContents, affected, explain);
+
+  // Keep the variables used in `trim` alive so that we can skip destruction
+  // and its overhead when we call `leave`.
+  [[maybe_unused]] const std::shared_ptr<void> state =
+      TrimUtil::trim(output, ninjaFile, ninjaFileContents, affected, explain);
   output.flush();
 
   if (!expectedFile.has_value()) {

--- a/src/trimutil.cpp
+++ b/src/trimutil.cpp
@@ -844,12 +844,13 @@ void ifAffectedMarkAllChildren(std::size_t index,
 
 }  // namespace
 
-void TrimUtil::trim(std::ostream& output,
-                    const std::filesystem::path& ninjaFile,
-                    const std::string& ninjaFileContents,
-                    std::istream& affected,
-                    bool explain) {
-  BuildContext ctx;
+std::shared_ptr<void> TrimUtil::trim(std::ostream& output,
+                                     const std::filesystem::path& ninjaFile,
+                                     const std::string& ninjaFileContents,
+                                     std::istream& affected,
+                                     bool explain) {
+  auto state = std::make_shared<BuildContext>();
+  BuildContext& ctx = *state;
 
   // Parse the build file, this needs to be the first thing so we choose the
   // canonical paths in the same way that ninja does
@@ -1061,6 +1062,8 @@ void TrimUtil::trim(std::ostream& output,
   const Timer writeTimer = CPUProfiler::start("output time");
   std::copy(ctx.parts.begin(), ctx.parts.end(),
             std::ostream_iterator<std::string_view>(output));
+
+  return state;
 }
 
 }  // namespace trimja

--- a/src/trimutil.h
+++ b/src/trimutil.h
@@ -25,6 +25,7 @@
 
 #include <filesystem>
 #include <iosfwd>
+#include <memory>
 #include <string>
 
 namespace trimja {
@@ -42,12 +43,14 @@ struct TrimUtil {
    * @param ninjaFileContents The contents of the original Ninja build file.
    * @param affected The input stream containing the list of affected files.
    * @param explain If true, prints to stderr why each build command was kept.
+   * @return A shared pointer containing the internal variables used in the
+   * algorithm to defer or avoid destruction.
    */
-  static void trim(std::ostream& output,
-                   const std::filesystem::path& ninjaFile,
-                   const std::string& ninjaFileContents,
-                   std::istream& affected,
-                   bool explain);
+  static std::shared_ptr<void> trim(std::ostream& output,
+                                    const std::filesystem::path& ninjaFile,
+                                    const std::string& ninjaFileContents,
+                                    std::istream& affected,
+                                    bool explain);
 };
 
 }  // namespace trimja


### PR DESCRIPTION
Based on benchmarks, running the destructor for all the objects in `BuildContext` takes 1-2% of the total time.  Instead we can skip it entirely by extending the lifetime of this object until we call `std::_Exit` - ending the application and skipping destructing all objects on the stack.

Using a `std::shared_ptr<void>` avoids us having to define `BuildContext` in the header file and bring in a load more include directives.  Another alternative is to make `TrimUtil` instantiable and have `BuildContext` as a (perhaps pimple) member variable.  However, this would require us to either reset all members in `BuildContext` when we call `trim`, or to ban `trim` being called multiple times.  Neither are as easy as the current chosen solution - even if it is a bit strange.