### PR TITLE
Make `*Util` components constructible

### DIFF
--- a/src/builddirutil.h
+++ b/src/builddirutil.h
@@ -28,11 +28,28 @@
 
 namespace trimja {
 
+namespace detail {
+class BuildDirContext;
+}  // namespace detail
+
 /**
- * @struct BuildDirUtil
+ * @class BuildDirUtil
  * @brief Utility functions for finding the build directory for a Ninja file.
  */
-struct BuildDirUtil {
+class BuildDirUtil {
+  std::unique_ptr<detail::BuildDirContext> m_imp;
+
+ public:
+  /**
+   * @brief Default constructor for BuildDirUtil.
+   */
+  BuildDirUtil();
+
+  /**
+   * @brief Destructor for BuildDirUtil.
+   */
+  ~BuildDirUtil();
+
   /**
    * @brief Determines the build directory from the given Ninja file and its
    * contents.
@@ -40,8 +57,8 @@ struct BuildDirUtil {
    * @param ninjaFileContents The contents of the Ninja file.
    * @return The path to the build directory.
    */
-  static std::filesystem::path builddir(const std::filesystem::path& ninjaFile,
-                                        const std::string& ninjaFileContents);
+  std::filesystem::path builddir(const std::filesystem::path& ninjaFile,
+                                 const std::string& ninjaFileContents);
 };
 
 }  // namespace trimja

--- a/src/trimja.m.cpp
+++ b/src/trimja.m.cpp
@@ -277,7 +277,8 @@ bool instrumentMemory = false;
 
   // If we have `--builddir` then ignore all other flags other than -f
   if (builddir) {
-    std::cout << BuildDirUtil::builddir(ninjaFile, ninjaFileContents).string()
+    BuildDirUtil util;
+    std::cout << util.builddir(ninjaFile, ninjaFileContents).string()
               << std::endl;
     leave(EXIT_SUCCESS);
   }
@@ -316,10 +317,8 @@ bool instrumentMemory = false;
       },
       outputFile);
 
-  // Keep the variables used in `trim` alive so that we can skip destruction
-  // and its overhead when we call `leave`.
-  [[maybe_unused]] const std::shared_ptr<void> state =
-      TrimUtil::trim(output, ninjaFile, ninjaFileContents, affected, explain);
+  TrimUtil util;
+  util.trim(output, ninjaFile, ninjaFileContents, affected, explain);
   output.flush();
 
   if (!expectedFile.has_value()) {

--- a/src/trimutil.h
+++ b/src/trimutil.h
@@ -30,11 +30,28 @@
 
 namespace trimja {
 
+namespace detail {
+class BuildContext;
+}  // namespace detail
+
 /**
- * @struct TrimUtil
+ * @class TrimUtil
  * @brief Utility to trim a Ninja build file based on a list of affected files.
  */
-struct TrimUtil {
+class TrimUtil {
+  std::unique_ptr<detail::BuildContext> m_imp;
+
+ public:
+  /**
+   * @brief Default constructor for TrimUtil.
+   */
+  TrimUtil();
+
+  /**
+   * @brief Destructor for TrimUtil.
+   */
+  ~TrimUtil();
+
   /**
    * @brief Trims the given Ninja build file based on the affected files.
    *
@@ -43,14 +60,12 @@ struct TrimUtil {
    * @param ninjaFileContents The contents of the original Ninja build file.
    * @param affected The input stream containing the list of affected files.
    * @param explain If true, prints to stderr why each build command was kept.
-   * @return A shared pointer containing the internal variables used in the
-   * algorithm to defer or avoid destruction.
    */
-  static std::shared_ptr<void> trim(std::ostream& output,
-                                    const std::filesystem::path& ninjaFile,
-                                    const std::string& ninjaFileContents,
-                                    std::istream& affected,
-                                    bool explain);
+  void trim(std::ostream& output,
+            const std::filesystem::path& ninjaFile,
+            const std::string& ninjaFileContents,
+            std::istream& affected,
+            bool explain);
 };
 
 }  // namespace trimja


### PR DESCRIPTION
Previously (603949f65421f5f3e055da36ac0888b4aa118267) we made some changes to `TrimUtil` to return a `std::shared_ptr<void>` containing the internal variables used in the algorithm.  This allowed us to defer destruction in `TrimUtil` so that we can skip it with `std::_Exit` later on - saving 1-2%.

The change did not sit well with me and is not very idiomatic.  This commit changes both `BuildDirUtil` and `TrimUtil` to be constructible and have their static methods changed to non-`const` member variables. We store the variables in a `std::unique_ptr` to defer destruction of the state until the destructor of the `*Util` - which is skipped when we call `std::_Exit`.