### PR TITLE
Remove unnecessary `time_point` conversion

### DIFF
--- a/src/depsreader.cpp
+++ b/src/depsreader.cpp
@@ -22,7 +22,6 @@
 
 #include "depsreader.h"
 #include "graph.h"
-#include "ninja_clock.h"
 
 #include <algorithm>
 #include <ios>
@@ -124,8 +123,7 @@ bool DepsReader::read(std::variant<PathRecordView, DepsRecordView>* output) {
       m_depsStorage.resize(numDependencies);
       std::generate_n(m_depsStorage.begin(), numDependencies,
                       [&] { return readBinary<std::int32_t>(m_deps); });
-      *output = DepsRecordView{outIndex, ninja_clock::to_file_clock(mtime),
-                               m_depsStorage};
+      *output = DepsRecordView{outIndex, mtime, m_depsStorage};
     }
   } catch (const std::ios_base::failure& e) {
     std::string msg;

--- a/src/depsreader.h
+++ b/src/depsreader.h
@@ -23,7 +23,8 @@
 #ifndef TRIMJA_DEPSREADER
 #define TRIMJA_DEPSREADER
 
-#include <chrono>
+#include "ninja_clock.h"
+
 #include <filesystem>
 #include <fstream>
 #include <span>
@@ -49,7 +50,7 @@ struct PathRecordView {
  */
 struct DepsRecordView {
   std::int32_t outIndex;
-  std::chrono::file_clock::time_point mtime;
+  ninja_clock::time_point mtime;
   std::span<const std::int32_t> deps;
 };
 


### PR DESCRIPTION
In general we don't need the `mtime` value from `DepsReader` for anything in trimja.  So instead we change the member variable to `ninja_clock::time_point` to avoid the conversion to `std::chrono::file_clock::time_point` - even if it is cheap.

We could do the same thing that we did with `LogReader` and pass a bitfield describing what fields we need.  However, it's extremely cheap to read the fields since it's a bit copy.