### PR TITLE
Add AddressSanitizer support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,17 @@ target_compile_definitions(trimja PRIVATE
 )
 set_property(TARGET trimja PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
 
+# Enable AddressSanitizer for Debug builds
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    if(MSVC)
+        target_compile_options(trimja PRIVATE /fsanitize=address)
+        target_link_options(trimja PRIVATE /fsanitize=address)
+    else()
+        target_compile_options(trimja PRIVATE -fsanitize=address)
+        target_link_options(trimja PRIVATE -fsanitize=address)
+    endif()
+endif()
+
 install(TARGETS trimja RUNTIME DESTINATION bin)
 
 if(WIN32)

--- a/thirdparty/ninja/getopt.c
+++ b/thirdparty/ninja/getopt.c
@@ -252,7 +252,7 @@ getopt_internal (int argc, char **argv, char *shortopts,
         match_chars = (possible_arg - argv[optind]) - optwhere;
       for (optindex = 0; longopts[optindex].name != NULL; optindex++)
         {
-          if (memcmp (argv[optind] + optwhere,
+          if (strncmp(argv[optind] + optwhere,
                       longopts[optindex].name, match_chars) == 0)
             {
               /* do we have an exact match? */


### PR DESCRIPTION
Enable AddressSanitizer on all platforms in debug builds.  This will slow down programs by about 2x so is quite acceptable in our use cases where tests run in ~50ms.

Replace a `memcmp` with `strncmp` in `getopt.c` because it seems to not compare byte-by-byte with an early exit on MSVC, and because of this is accessible memory past the end of the string.  It is replaced with `strncmp`, which fixes the issue.

Luckily we don't have any other issues arising in trimja that were highlighted by AddressSanitizer.