### PR TITLE
Remove `resetValue` methods

### DIFF
--- a/src/basicscope.cpp
+++ b/src/basicscope.cpp
@@ -22,6 +22,8 @@
 
 #include "basicscope.h"
 
+#include <utility>
+
 namespace trimja {
 
 BasicScope::BasicScope() = default;
@@ -43,17 +45,8 @@ BasicScope& BasicScope::operator=(const BasicScope& rhs) {
   return *this;
 }
 
-std::string_view BasicScope::set(std::string_view key, std::string&& value) {
-  // By design to avoid accidental copies, `fixed_string` does not have a copy
-  // constructor so we cannot use `operator[]`.  Instead we can use `emplace` to
-  // achieve basically the same performance.
-  return m_variables.try_emplace(key, std::move(value)).first->second;
-}
-
-std::string& BasicScope::resetValue(std::string_view key) {
-  std::string& value = m_variables.try_emplace(key, "").first->second;
-  value.clear();
-  return value;
+void BasicScope::set(std::string_view key, std::string&& value) {
+  m_variables.insert_or_assign(key, std::move(value));
 }
 
 bool BasicScope::appendValue(std::string& output, std::string_view name) const {

--- a/src/basicscope.h
+++ b/src/basicscope.h
@@ -78,20 +78,8 @@ class BasicScope {
    * @brief Sets a variable in the scope.
    * @param key The name of the variable.
    * @param value The value of the variable.
-   * @return A reference to the inserted value.
    */
-  std::string_view set(std::string_view key, std::string&& value);
-
-  /**
-   * @brief Resets the value of a variable in the scope.
-   *
-   * This method sets the value associated with the specified key to an empty
-   * string. If the key does not exist, it inserts the key with an empty value.
-   *
-   * @param key The name of the variable to reset.
-   * @return A reference to the reset value.
-   */
-  std::string& resetValue(std::string_view key);
+  void set(std::string_view key, std::string&& value);
 
   /**
    * @brief Appends the value of a variable to the output string.

--- a/src/builddirutil.cpp
+++ b/src/builddirutil.cpp
@@ -71,7 +71,9 @@ class BuildDirContext {
   void operator()(DefaultReader& r) const { consume(r.readPaths()); }
 
   void operator()(const VariableReader& r) {
-    evaluate(fileScope.resetValue(r.name()), r.value(), fileScope);
+    std::string value;
+    evaluate(value, r.value(), fileScope);
+    fileScope.set(r.name(), std::move(value));
   }
 
   void operator()(const IncludeReader& r) {

--- a/src/edgescope.h
+++ b/src/edgescope.h
@@ -83,23 +83,9 @@ class EdgeScope {
    *
    * @param key The name of the variable to set.
    * @param value The value to assign to the variable.
-   * @return A string view of the stored value.
    */
-  std::string_view set(std::string_view key, std::string&& value) {
-    return m_local.set(key, std::move(value));
-  }
-
-  /**
-   * @brief Resets the value of a variable in the scope.
-   *
-   * This method sets the value associated with the specified key to an empty
-   * string. If the key does not exist, it inserts the key with an empty value.
-   *
-   * @param key The name of the variable to reset.
-   * @return A reference to the reset value.
-   */
-  std::string& resetValue(std::string_view key) {
-    return m_local.resetValue(key);
+  void set(std::string_view key, std::string&& value) {
+    m_local.set(key, std::move(value));
   }
 
   /**

--- a/tests/variables/build.ninja
+++ b/tests/variables/build.ninja
@@ -14,6 +14,9 @@ build out2: copy in2
   pool = bye
 build out3: copy in3
   command = ninja --version Overwrite everything!
-filename = in1
+recursive = n
+recursive = ${recursive}1
+recursive = i${recursive}
+filename = $recursive
 build $filename.out: copy $filename
 build $filename.out2: copy $filename.other

--- a/tests/variables/expected.ninja
+++ b/tests/variables/expected.ninja
@@ -6,6 +6,9 @@ foo = 42
 build out1: phony
 build out2: phony
 build out3: phony
-filename = in1
+recursive = n
+recursive = ${recursive}1
+recursive = i${recursive}
+filename = $recursive
 build $filename.out: phony
 build $filename.out2: phony


### PR DESCRIPTION
libfuzzer has found an issue when we reassign the same variable multiple times.  Given a Ninja build file,

```
var = cous
var = $var$var
```

The variable `var` should say "couscous" but our implementation would first reset `var` to the empty string and then concatenate the empty string with itself to give "".

However, libfuzzer also found a crash in this situation as we are keeping references around and appending `std::string` to itself.  In the case we need to reallocate we are have problems.

This commit removes `resetValue` and instead we create a new `std::string` each time.  This is slower in the case where we overwrite the same variable, however this is a rare situation and the common case is to have new variables.

We never use the return value of the `set` methods so this has been removed as well to avoid any similar issues in the future.