### PR TITLE
Restrict ninja version to 1.11.1 on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: seanmiddleditch/gha-setup-ninja@master
+      with:
+        version: '1.11.1'
     - name: Configure CMake
       run: >
         cmake -B output


### PR DESCRIPTION
The latest version of ninja is 1.12.x and this has a change to the log format, increasing the log number from v5 to v7.  This was fixed recently in trimja, but that version has yet to be published.

Our published version of `trimja-action` therefore has a version of `trimja` that is cannot support ninja 1.12.x.  For now we restrict our version of ninja on CI until we publish a new trimja version.