### PR TITLE
Compile with GCC on CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,13 +12,20 @@ jobs:
       fail-fast: false
       matrix:
         environment: [
-          {name: Linux, os: ubuntu-20.04, cpp: clang++-12, c: clang-12},
-          {name: MacOS, os: macos-13, cpp: clang++, c: clang},
-          {name: Windows, os: windows-latest, cpp: cl, c: cl},
+          # Linux (Clang) and MacOS must use the oldest GitHub Action runner
+          # since we want to compile against the oldest libc version
+          # possible.  This means that all binaries created will be compatible
+          # with all GitHub Action runners. For Linux (GCC) with choose the
+          # oldest version that supports everything we have on the other
+          # platforms to maximise compiler compatibility.
+          {name: Linux (clang), image: ubuntu-20.04, cpp: clang++-12, c: clang-12, generator: Ninja, clang-tidy: true},
+          {name: Linux (gcc), image: ubuntu-22.04, cpp: g++-12, c: gcc-12, generator: Ninja},
+          {name: MacOS, image: macos-13, cpp: clang++, c: clang, generator: Ninja},
+          {name: Windows, image: windows-latest, cpp: cl, c: cl},
         ]
         build_type: [Debug, Release]
     name: ${{ matrix.environment.name }} (${{ matrix.build_type }})
-    runs-on: ${{ matrix.environment.os }}
+    runs-on: ${{ matrix.environment.image }}
     permissions:
       contents: write
     steps:
@@ -32,8 +39,8 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{ matrix.environment.cpp }}
         -DCMAKE_C_COMPILER=${{ matrix.environment.c }}
         ${{ format('-D{0}={1}', matrix.environment.name == 'Windows' && 'CMAKE_CONFIGURATION_TYPES' || 'CMAKE_BUILD_TYPE', matrix.build_type) }}
-        ${{ matrix.environment.name != 'Windows' && '-G Ninja' || ''}}
-        ${{ matrix.environment.name == 'Linux' && '-DENABLE_CLANG_TIDY=ON' || ''}}
+        ${{ matrix.environment.generator != '' && format('-G {0}', matrix.environment.generator) || ''}}
+        ${{ matrix.environment.clang-tidy && '-DENABLE_CLANG_TIDY=ON' || ''}}
     - uses: elliotgoodrich/trimja-action@v1
       # Skip Windows (which doesn't yet use Ninja) and releases
       if: matrix.environment.name != 'Windows' && !startsWith(github.ref, 'refs/tags/')

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     else()
         target_compile_options(trimja PRIVATE -fsanitize=address -fsanitize=undefined)
         # Keep frame pointers for better stack traces
-        target_link_options(trimja PRIVATE -fno-omit-frame-pointer -fsanitize=address)
+        target_link_options(trimja PRIVATE -fno-omit-frame-pointer -fsanitize=address -fsanitize=undefined)
     endif()
 endif()
 

--- a/src/logreader.cpp
+++ b/src/logreader.cpp
@@ -23,6 +23,7 @@
 #include "logreader.h"
 #include "ninja_clock.h"
 
+#include <algorithm>
 #include <array>
 #include <cassert>
 #include <charconv>
@@ -37,7 +38,8 @@ std::array<std::string_view, N> splitOnTab(std::string_view in) {
   const auto end = in.end();
   for (std::string_view& part : parts) {
     const auto tab = std::find(it, end, '\t');
-    part = std::string_view{&*it, static_cast<std::size_t>(tab - it)};
+    part = std::string_view{&*it,
+                            static_cast<std::string_view::size_type>(tab - it)};
     it = tab + std::min<std::size_t>(sizeof('\t'), end - tab);
   }
   return parts;

--- a/src/manifestparser.cpp
+++ b/src/manifestparser.cpp
@@ -134,13 +134,10 @@ LetRangeReader::sentinel LetRangeReader::end() const {
   return sentinel{};
 }
 
-PathRangeReader::iterator::iterator(Lexer* lexer, EvalString* storage)
-    : iterator(lexer, storage, static_cast<Lexer::Token>(-1)) {}
-
 PathRangeReader::iterator::iterator(Lexer* lexer,
                                     EvalString* storage,
-                                    Lexer::Token lastToken)
-    : detail::BaseReader(lexer, storage), m_expectedLastToken(lastToken) {
+                                    int lastToken)
+    : detail::BaseReader{lexer, storage}, m_expectedLastToken{lastToken} {
   if (m_lexer) {
     ++*this;
   }
@@ -158,8 +155,8 @@ PathRangeReader::iterator& PathRangeReader::iterator::operator++() {
     throw std::runtime_error(err);
   }
   if (m_storage->empty()) {
-    if (static_cast<int>(m_expectedLastToken) != -1) {
-      expectToken(m_lexer, m_expectedLastToken);
+    if (m_expectedLastToken != -1) {
+      expectToken(m_lexer, static_cast<Lexer::Token>(m_expectedLastToken));
     }
     m_lexer = nullptr;
   }
@@ -183,13 +180,13 @@ bool operator!=(const PathRangeReader::iterator& iter,
 PathRangeReader::PathRangeReader() : PathRangeReader{nullptr, nullptr} {}
 
 PathRangeReader::PathRangeReader(Lexer* lexer, EvalString* storage)
-    : PathRangeReader(lexer, storage, static_cast<Lexer::Token>(-1)) {}
+    : detail::BaseReader{lexer, storage}, m_expectedLastToken{-1} {}
 
 PathRangeReader::PathRangeReader(Lexer* lexer,
                                  EvalString* storage,
                                  Lexer::Token expectedLastToken)
-    : detail::BaseReader(lexer, storage),
-      m_expectedLastToken(expectedLastToken) {}
+    : detail::BaseReader{lexer, storage},
+      m_expectedLastToken{expectedLastToken} {}
 
 PathRangeReader::iterator PathRangeReader::begin() {
   return iterator{m_lexer, m_storage, m_expectedLastToken};

--- a/src/manifestparser.h
+++ b/src/manifestparser.h
@@ -133,11 +133,10 @@ class PathRangeReader : public detail::BaseReader {
     using value_type = EvalString;
 
    private:
-    Lexer::Token m_expectedLastToken;
+    int m_expectedLastToken;
 
    public:
-    iterator(Lexer* lexer, value_type* storage);
-    iterator(Lexer* lexer, value_type* storage, Lexer::Token lastToken);
+    iterator(Lexer* lexer, value_type* storage, int lastToken = -1);
 
     const value_type& operator*() const;
 
@@ -148,7 +147,7 @@ class PathRangeReader : public detail::BaseReader {
   };
 
  private:
-  Lexer::Token m_expectedLastToken;
+  int m_expectedLastToken;
 
  public:
   PathRangeReader();

--- a/src/trimja.m.cpp
+++ b/src/trimja.m.cpp
@@ -134,7 +134,8 @@ bool instrumentMemory = false;
 
 }  // namespace
 
-[[noreturn]] int main(int argc, char* argv[]) try {
+// NOLINTNEXTLINE(modernize-avoid-c-arrays)
+[[noreturn]] int mainImp(int argc, char* argv[]) try {
   // Decorate as [[noreturn]] to make sure we always call `leave`, which
   // avoids the overhead of destructing objects on the stack.
   using namespace trimja;
@@ -364,4 +365,11 @@ bool instrumentMemory = false;
 } catch (const std::exception& e) {
   std::cout << e.what() << std::endl;
   leave(EXIT_FAILURE);
+}
+
+int main(int argc, char* argv[]) {
+  // We cannot decorate `main` with `[[noreturn]]` in gcc since it warns on the
+  // implicit `return 0;`. So instead we call out to another function that isn't
+  // special.
+  return mainImp(argc, argv);
 }


### PR DESCRIPTION
We should be able to target GCC as well as our current targets without
much issue.  There were a few fixes needed:

  * Some transitive includes are discovered with gcc's standard library
  * GCC has a few more compiler errors/warnings we need to fix
  * UBSan in GCC finds the case where we case `-1` to a `Lexer::Token`
  * Order of evaluation calculating offsets meant we had UB when the
    `vector` had to resize and we did pointer arithmetic with pointers
    not pointing within the same array