### PR TITLE
Fix normalization for segments starting with `..`

### DIFF
--- a/thirdparty/ninja/util.cc
+++ b/thirdparty/ninja/util.cc
@@ -185,7 +185,7 @@ void CanonicalizePath(char* path, std::size_t* len) {
     if (src[0] == '.') {
       if (component_len == 1)
         break;  // Ignore trailing '.' (e.g. 'foo/.' -> 'foo/')
-      if (src[1] == '.') {
+      if (component_len == 2 && src[1] == '.') {
         // Handle '..'. Back up if possible.
         if (component_count > 0) {
           while (--dst > dst0 && !IsPathSeparator(dst[-1])) {


### PR DESCRIPTION
Replicate the change in
https://github.com/ninja-build/ninja/pull/2398 where path segments starting with `..` were taken to be `..`. e.g. `a/b/..c` would incorrectly be normalized to `a`.