### PR TITLE
Don't build releases on gcc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,10 +18,10 @@ jobs:
           # with all GitHub Action runners. For Linux (GCC) with choose the
           # oldest version that supports everything we have on the other
           # platforms to maximise compiler compatibility.
-          {name: Linux (clang), image: ubuntu-20.04, cpp: clang++-12, c: clang-12, generator: Ninja, clang-tidy: true},
-          {name: Linux (gcc), image: ubuntu-22.04, cpp: g++-12, c: gcc-12, generator: Ninja},
-          {name: MacOS, image: macos-13, cpp: clang++, c: clang, generator: Ninja},
-          {name: Windows, image: windows-latest, cpp: cl, c: cl},
+          {name: Linux (clang), image: ubuntu-20.04, cpp: clang++-12, c: clang-12, generator: Ninja, clang-tidy: true, package: true},
+          {name: Linux (gcc), image: ubuntu-22.04, cpp: g++-12, c: gcc-12, generator: Ninja, package: false},
+          {name: MacOS, image: macos-13, cpp: clang++, c: clang, generator: Ninja, package: true},
+          {name: Windows, image: windows-latest, cpp: cl, c: cl, package: true},
         ]
         build_type: [Debug, Release]
     name: ${{ matrix.environment.name }} (${{ matrix.build_type }})
@@ -58,14 +58,14 @@ jobs:
     - name: Test
       run: ctest --test-dir output --build-config ${{ matrix.build_type }} --output-on-failure
     - name: Install
-      if: startsWith(github.ref, 'refs/tags/') && matrix.build_type == 'Release'
+      if: startsWith(github.ref, 'refs/tags/') && matrix.build_type == 'Release' && matrix.environment.package
       run: cmake --build output --config ${{ matrix.build_type }} --target package
     - name: Generate Changelog
       run: git show -s --format='%b' > output/CHANGELOG.txt
-      if: startsWith(github.ref, 'refs/tags/') && matrix.build_type == 'Release'
+      if: startsWith(github.ref, 'refs/tags/') && matrix.build_type == 'Release' && matrix.environment.package
     - name: Release
       uses: softprops/action-gh-release@v2
-      if: startsWith(github.ref, 'refs/tags/') && matrix.build_type == 'Release'
+      if: startsWith(github.ref, 'refs/tags/') && matrix.build_type == 'Release' && matrix.environment.package
       with:
         body_path: output/CHANGELOG.txt
         files: |


### PR DESCRIPTION
Stop the clang and gcc builds both attempting to create an upload a Linux artifact when creating releases.