### PR TITLE
Use latest ninja in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,8 +31,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: seanmiddleditch/gha-setup-ninja@master
-      with:
-        version: '1.11.1'
     - name: Configure CMake
       run: >
         cmake -B output


### PR DESCRIPTION
After the publication of `trimja-action@v1.5.0` (which is also tagged as `trimja-action@v1`) we can now handle the latest build log format generated by ninja 1.12.x.