### PR TITLE
Add fuzzing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,9 @@ jobs:
         ${{ matrix.environment.clang-tidy && '-DENABLE_CLANG_TIDY=ON' || ''}}
     - uses: elliotgoodrich/trimja-action@v1
       # Skip Windows (which doesn't yet use Ninja) and releases
-      if: matrix.environment.name != 'Windows' && !startsWith(github.ref, 'refs/tags/')
+      # TODO: Figure out why trimja is failing on CI
+      #if: matrix.environment.name != 'Windows' && !startsWith(github.ref, 'refs/tags/')
+      if: false
       with:
         path: output/build.ninja
         build-configuration: ${{ matrix.build_type }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,15 +18,21 @@ if(ENABLE_CLANG_TIDY)
     endif()
 endif()
 
+# Enable ASAN in debug mode for supported compilers
+# MSVC is not supported yet as we need to set up the PATH to `clang_rt.asan_dynamic*.dll`
+set(ENABLE_SANITIZERS $<AND:$<NOT:$<CXX_COMPILER_ID:MSVC>>,$<CONFIG:Debug>>)
+
+# Enable fuzzing for Clang in debug mode
+set(ENABLE_FUZZING $<AND:$<CXX_COMPILER_ID:Clang>,$<CONFIG:Debug>>)
 
 ###############################################################################
 # trimja                                                                      #
 ###############################################################################
 
-add_executable(
-    trimja
+add_library(
+    core
+    STATIC
     src/all.natvis
-    src/trimja.m.cpp
     src/allocationprofiler.cpp
     src/basicscope.cpp
     src/builddirutil.cpp
@@ -54,31 +60,39 @@ set_source_files_properties(
     PROPERTIES SKIP_LINTING ON
 )
 
-target_compile_definitions(trimja PRIVATE TRIMJA_VERSION="${CMAKE_PROJECT_VERSION}")
-target_include_directories(trimja PRIVATE src)
-target_include_directories(trimja SYSTEM PRIVATE thirdparty)
-target_compile_options(trimja PRIVATE
-    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic>
-    $<$<CXX_COMPILER_ID:MSVC>:/W4>
+target_include_directories(core PUBLIC src)
+target_include_directories(core SYSTEM PUBLIC thirdparty)
+target_compile_options(core PUBLIC
+    $<IF:$<CXX_COMPILER_ID:MSVC>,/W4,-Wall -Wextra -Wpedantic>
 )
-target_compile_definitions(trimja PRIVATE
+target_compile_definitions(core PUBLIC
     # debug iterators cause default ctor of std::string and std::vector to allocate
-    $<$<CXX_COMPILER_ID:MSVC>:_ITERATOR_DEBUG_LEVEL=0>
-    $<$<CXX_COMPILER_ID:MSVC>:NOMINMAX>
+    $<$<CXX_COMPILER_ID:MSVC>:_ITERATOR_DEBUG_LEVEL=0 NOMINMAX>
 )
-set_property(TARGET trimja PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
 
-# Enable AddressSanitizer and UBSan (if available) for Debug builds
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    if(MSVC)
-        target_compile_options(trimja PRIVATE /fsanitize=address)
-        target_link_options(trimja PRIVATE /fsanitize=address)
-    else()
-        target_compile_options(trimja PRIVATE -fsanitize=address -fsanitize=undefined)
-        # Keep frame pointers for better stack traces
-        target_link_options(trimja PRIVATE -fno-omit-frame-pointer -fsanitize=address -fsanitize=undefined)
-    endif()
-endif()
+# Skip link time optimization when we're fuzzing as they don't play nicely
+set_property(TARGET core PROPERTY INTERPROCEDURAL_OPTIMIZATION $<NOT:${ENABLE_FUZZING}>)
+
+target_compile_options(
+    core PUBLIC
+    $<$<AND:${ENABLE_SANITIZERS},$<CXX_COMPILER_ID:MSVC>>:/fsanitize=address>
+    $<$<AND:${ENABLE_SANITIZERS},$<NOT:$<CXX_COMPILER_ID:MSVC>>>:-fsanitize=address,undefined>
+    $<${ENABLE_FUZZING}:-fsanitize=fuzzer-no-link>
+)
+target_link_options(
+    core PUBLIC
+    # MSVC Incremental linking does not work when address sanitizer is enabled
+    $<$<AND:${ENABLE_SANITIZERS},$<CXX_COMPILER_ID:MSVC>>:/INCREMENTAL:NO>
+    $<$<AND:${ENABLE_SANITIZERS},$<NOT:$<CXX_COMPILER_ID:MSVC>>>:-fsanitize=address,undefined -fno-omit-frame-pointer>
+)
+
+add_executable(
+    trimja
+    src/trimja.m.cpp
+)
+target_compile_definitions(trimja PRIVATE TRIMJA_VERSION="${CMAKE_PROJECT_VERSION}")
+set_property(TARGET trimja PROPERTY INTERPROCEDURAL_OPTIMIZATION $<NOT:${ENABLE_FUZZING}>)
+target_link_libraries(trimja core)
 
 install(TARGETS trimja RUNTIME DESTINATION bin)
 
@@ -92,6 +106,26 @@ set(CPACK_PACKAGE_INSTALL_DIRECTORY trimja)
 set(CPACK_NSIS_MODIFY_PATH ON)
 set(CPACK_NSIS_IGNORE_LICENSE_PAGE ON)
 include(CPack)
+
+file(
+    GLOB TRIMJA_FUZZING_TARGETS
+    RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/src/
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/*.fuzz.cpp
+)
+foreach(FUZZ_TARGET ${TRIMJA_FUZZING_TARGETS})
+    if(${FUZZ_TARGET} MATCHES "^(.+)\.fuzz\.cpp$")
+        string(CONCAT FUZZ_TARGET_NAME "fuzz" ${CMAKE_MATCH_1})
+        add_executable(
+            ${FUZZ_TARGET_NAME}
+            src/${FUZZ_TARGET}
+            $<$<NOT:${ENABLE_FUZZING}>:src/nofuzzing.m.cpp>
+        )
+        target_link_options(${FUZZ_TARGET_NAME} PRIVATE $<${ENABLE_FUZZING}:-fsanitize=fuzzer>)
+        target_link_libraries(${FUZZ_TARGET_NAME} core)
+    else()
+        message(FATAL_ERROR "Regex should match")
+    endif()
+endforeach()
 
 # Generate test files for the absolute/relative unit test
 get_filename_component(ABSOLUTE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tests/absolute/relative" ABSOLUTE)

--- a/src/builddirutil.fuzz.cpp
+++ b/src/builddirutil.fuzz.cpp
@@ -1,0 +1,39 @@
+// MIT License
+//
+// Copyright (c) 2025 Elliot Goodrich
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "builddirutil.h"
+
+#include <sstream>
+#include <string>
+
+#include <stdint.h>  // NOLINT(modernize-deprecated-headers)
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  using namespace trimja;
+  const std::string input{reinterpret_cast<const char*>(data), size};
+  try {
+    BuildDirUtil util;
+    util.builddir(std::filesystem::path{}, input);
+  } catch (const std::exception&) {
+  }
+  return 0;
+}

--- a/src/depsreader.fuzz.cpp
+++ b/src/depsreader.fuzz.cpp
@@ -1,0 +1,42 @@
+// MIT License
+//
+// Copyright (c) 2025 Elliot Goodrich
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "depsreader.h"
+
+#include <sstream>
+#include <string>
+
+#include <stdint.h>  // NOLINT(modernize-deprecated-headers)
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  using namespace trimja;
+  const std::string input{reinterpret_cast<const char*>(data), size};
+  try {
+    std::istringstream stream{input, std::ios_base::in | std::ios_base::binary};
+    DepsReader reader{stream};
+    for (auto&& entry : reader) {
+      (void)entry;
+    }
+  } catch (const std::exception&) {
+  }
+  return 0;
+}

--- a/src/logreader.cpp
+++ b/src/logreader.cpp
@@ -127,7 +127,7 @@ bool LogReader::read(LogEntry* output) {
   }
 
   if (m_fields & LogEntry::Fields::mtime) {
-    ninja_clock::rep ticks;
+    ninja_clock::rep ticks = {};
     std::from_chars(parts[2].data(), parts[2].data() + parts[2].size(), ticks);
     output->mtime = ninja_clock::to_file_clock(
         ninja_clock::time_point{ninja_clock::duration{ticks}});

--- a/src/logreader.fuzz.cpp
+++ b/src/logreader.fuzz.cpp
@@ -1,0 +1,42 @@
+// MIT License
+//
+// Copyright (c) 2025 Elliot Goodrich
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "logreader.h"
+
+#include <sstream>
+#include <string>
+
+#include <stdint.h>  // NOLINT(modernize-deprecated-headers)
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  using namespace trimja;
+  const std::string input{reinterpret_cast<const char*>(data), size};
+  try {
+    std::istringstream stream{input, std::ios_base::in};
+    LogReader reader{stream};
+    for (auto&& entry : reader) {
+      (void)entry;
+    }
+  } catch (const std::exception&) {
+  }
+  return 0;
+}

--- a/src/nofuzzing.m.cpp
+++ b/src/nofuzzing.m.cpp
@@ -1,0 +1,30 @@
+// MIT License
+//
+// Copyright (c) 2025 Elliot Goodrich
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <iostream>
+
+int main(int, char*[]) {
+  // This translation unit is compiled into our fuzz targets when fuzzing is not
+  // enabled in order to have a valid entry point for the executable.
+  std::cout << "Fuzzing not supported";
+  return 1;
+}


### PR DESCRIPTION
Add 3 fuzzing entry points, each testing one of the 3 parsers we have:

  * `BuildDirUtil` (ninja build parser)
  * `DepsReader` (`.ninja_deps` parser)
  * `LogReader` (`.ninja_log` parser)

In order to do this we break up `trimja` project into a `core` static
library and the `trimja` executable.  This allows us to link the `core`
library into the separate fuzzing executables.

To keep things more managable, the `CMakeLists.txt` file has been neated
up, including moving some conditionals to generator expressions.  This
uncovered an issue where we weren't actually enabled Address Sanitizer
on MSVC because its generator generates multiple configurations at the
same time.  The sanitizers can't be enabled just yet because we need to
set up the path the correct DLL on Windows.  This can be done in a
follow up commit.

In an unrelated problem, `trimja` is failing when running on CI.  This
has been disabled for the moment until it can be fixed.