### PR TITLE
Run fuzzing corpora on all platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,14 @@ foreach(FUZZ_TARGET ${TRIMJA_FUZZING_TARGETS})
                     COMMAND_EXPAND_LISTS
                 )
             endif()
+        else()
+            # If fuzzing isn't available, then we build an executable with our own `main` that
+            # can iterate through a directory and run the corpora within it
+            add_test(
+                NAME trimja.fuzz.${FUZZ_TARGET_NAME}
+                COMMAND $<TARGET_FILE:${FUZZ_TARGET_NAME}> --directory ${FUZZ_TARGET_NAME}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/corpora/
+            )
         endif()
     else()
         message(FATAL_ERROR "Regex should match")


### PR DESCRIPTION
Though fuzzing is not available in all platforms, we can at least run the existing fuzzing corpora for all platforms to make sure that there are no problems.  This is simple to do by editing our own entry point in `nofuzzing.m.cpp` to iterate through files in a directory and running these against the fuzzing entry point.