### PR TITLE
Reduce size of `EvalString`

### DIFF
--- a/src/evalstring.h
+++ b/src/evalstring.h
@@ -29,6 +29,8 @@
 
 namespace trimja {
 
+class EvalStringBuilder;
+
 /**
  * @class EvalString
  * @brief A class to represent and evaluate strings containing both text and
@@ -40,9 +42,10 @@ class EvalString {
   // later on if a smaller type help with memory or performance.
   using Offset = std::size_t;
 
+  friend class EvalStringBuilder;
+
  private:
   std::string m_data;
-  Offset m_lastTextSegmentLength;
 
  public:
   /**
@@ -80,11 +83,6 @@ class EvalString {
   EvalString();
 
   /**
-   * @brief Clears the EvalString.
-   */
-  void clear();
-
-  /**
    * @brief Checks if the EvalString is empty.
    */
   bool empty() const;
@@ -98,6 +96,27 @@ class EvalString {
    * @brief Gets the end iterator.
    */
   const_iterator end() const;
+};
+
+/**
+ * @class EvalStringBuilder
+ * @brief A class to represent and evaluate strings containing both text and
+ * variables.
+ */
+class EvalStringBuilder {
+  EvalString m_str;
+  EvalString::Offset m_lastTextSegmentLength = 0;
+
+ public:
+  /**
+   * @brief Default constructor.
+   */
+  EvalStringBuilder();
+
+  /**
+   * @brief Clears the held EvalString.
+   */
+  void clear();
 
   /**
    * @brief Appends text to the EvalString, consolidating consecutive text
@@ -111,6 +130,11 @@ class EvalString {
    * @param name The name of the variable to append.  This must not be empty.
    */
   void appendVariable(std::string_view name);
+
+  /**
+   * @brief Return a reference to the held EvalString.
+   */
+  const EvalString& str() const;
 };
 
 /**

--- a/src/manifestparser.h
+++ b/src/manifestparser.h
@@ -45,10 +45,10 @@ namespace detail {
 struct BaseReader {
  protected:
   Lexer* m_lexer;
-  EvalString* m_storage;
+  EvalStringBuilder* m_storage;
 
  public:
-  BaseReader(Lexer* lexer, EvalString* storage);
+  BaseReader(Lexer* lexer, EvalStringBuilder* storage);
   const char* position() const;
 };
 
@@ -61,7 +61,9 @@ struct BaseReaderWithStart : public BaseReader {
   const char* m_start;
 
  public:
-  BaseReaderWithStart(Lexer* lexer, EvalString* storage, const char* start);
+  BaseReaderWithStart(Lexer* lexer,
+                      EvalStringBuilder* storage,
+                      const char* start);
   const char* start() const;
   std::size_t bytesParsed() const;
 };
@@ -76,7 +78,7 @@ class VariableReader : public detail::BaseReaderWithStart {
   std::string_view m_name;
 
  public:
-  VariableReader(Lexer* lexer, EvalString* storage, const char* start);
+  VariableReader(Lexer* lexer, EvalStringBuilder* storage, const char* start);
   std::string_view name() const;
   const EvalString& value() const;
 
@@ -86,7 +88,7 @@ class VariableReader : public detail::BaseReaderWithStart {
       return m_name;
     }
     if constexpr (I == 1) {
-      return *m_storage;
+      return m_storage->str();
     }
   }
 };
@@ -104,7 +106,7 @@ class LetRangeReader : public detail::BaseReaderWithStart {
     using difference_type = std::ptrdiff_t;
     using value_type = VariableReader;
 
-    iterator(Lexer* lexer, EvalString* storage);
+    iterator(Lexer* lexer, EvalStringBuilder* storage);
 
     value_type operator*();
     iterator& operator++();
@@ -114,7 +116,7 @@ class LetRangeReader : public detail::BaseReaderWithStart {
   };
 
  public:
-  LetRangeReader(Lexer* lexer, EvalString* storage);
+  LetRangeReader(Lexer* lexer, EvalStringBuilder* storage);
 
   iterator begin();
   sentinel end() const;
@@ -136,7 +138,7 @@ class PathRangeReader : public detail::BaseReader {
     int m_expectedLastToken;
 
    public:
-    iterator(Lexer* lexer, value_type* storage, int lastToken = -1);
+    iterator(Lexer* lexer, EvalStringBuilder* storage, int lastToken = -1);
 
     const value_type& operator*() const;
 
@@ -151,9 +153,9 @@ class PathRangeReader : public detail::BaseReader {
 
  public:
   PathRangeReader();
-  PathRangeReader(Lexer* lexer, EvalString* storage);
+  PathRangeReader(Lexer* lexer, EvalStringBuilder* storage);
   PathRangeReader(Lexer* lexer,
-                  EvalString* storage,
+                  EvalStringBuilder* storage,
                   Lexer::Token expectedLastToken);
   iterator begin();
   sentinel end() const;
@@ -168,7 +170,7 @@ class PoolReader : public detail::BaseReaderWithStart {
 
  public:
   PoolReader();  ///<  For private use
-  PoolReader(Lexer* lexer, EvalString* storage, const char* start);
+  PoolReader(Lexer* lexer, EvalStringBuilder* storage, const char* start);
   std::string_view name() const;
   LetRangeReader readVariables();
 };
@@ -198,7 +200,7 @@ class RuleReader : public detail::BaseReaderWithStart {
   std::string_view m_name;
 
  public:
-  RuleReader(Lexer* lexer, EvalString* storage, const char* start);
+  RuleReader(Lexer* lexer, EvalStringBuilder* storage, const char* start);
   std::string_view name() const;
   LetRangeReader readVariables();
 };
@@ -219,7 +221,7 @@ class DefaultReader : public detail::BaseReaderWithStart {
  */
 class IncludeReader : public detail::BaseReaderWithStart {
  public:
-  IncludeReader(Lexer* lexer, EvalString* storage, const char* start);
+  IncludeReader(Lexer* lexer, EvalStringBuilder* storage, const char* start);
   const EvalString& path() const;
 
   // Return the path passed in to the `ManifestReader` constructor.
@@ -232,7 +234,7 @@ class IncludeReader : public detail::BaseReaderWithStart {
  */
 class SubninjaReader : public detail::BaseReaderWithStart {
  public:
-  SubninjaReader(Lexer* lexer, EvalString* storage, const char* start);
+  SubninjaReader(Lexer* lexer, EvalStringBuilder* storage, const char* start);
   const EvalString& path() const;
 
   // Return the path passed in to the `ManifestReader` constructor.
@@ -245,7 +247,7 @@ class SubninjaReader : public detail::BaseReaderWithStart {
  */
 class ManifestReader {
   Lexer m_lexer;
-  EvalString m_storage;
+  EvalStringBuilder m_storage;
 
  public:
   class sentinel {};
@@ -264,7 +266,7 @@ class ManifestReader {
     value_type m_value;
 
    public:
-    iterator(Lexer* lexer, EvalString* storage);
+    iterator(Lexer* lexer, EvalStringBuilder* storage);
 
     value_type operator*() const;
 

--- a/thirdparty/ninja/lexer.cc
+++ b/thirdparty/ninja/lexer.cc
@@ -684,7 +684,7 @@ yy95:
   return true;
 }
 
-bool Lexer::ReadEvalString(trimja::EvalString *eval, bool path, std::string* err) {
+bool Lexer::ReadEvalString(trimja::EvalStringBuilder *eval, bool path, std::string* err) {
   const char* p = ofs_;
   const char* q;
   const char* start;

--- a/thirdparty/ninja/lexer.h
+++ b/thirdparty/ninja/lexer.h
@@ -28,7 +28,7 @@
 //   * Change 'ReadIdent' to return the key as a `string_view`
 //   * Store the filename as a `std::filesystem::path` and add `getFilename`
 //     accessor
-//   * Replace `EvalString` with `trimja::EvalString`
+//   * Replace `EvalString` with `trimja::EvalStringBuilder`
 
 #ifndef NINJA_LEXER_H_
 #define NINJA_LEXER_H_
@@ -38,7 +38,7 @@
 #include <string_view>
 
 namespace trimja {
-class EvalString;
+class EvalStringBuilder;
 }  // namespace trimja
 
 struct Lexer {
@@ -95,13 +95,13 @@ struct Lexer {
   /// Read a path (complete with $escapes).
   /// Returns false only on error, returned path may be empty if a delimiter
   /// (space, newline) is hit.
-  bool ReadPath(trimja::EvalString* path, std::string* err) {
+  bool ReadPath(trimja::EvalStringBuilder* path, std::string* err) {
     return ReadEvalString(path, true, err);
   }
 
   /// Read the value side of a var = value line (complete with $escapes).
   /// Returns false only on error.
-  bool ReadVarValue(trimja::EvalString* value, std::string* err) {
+  bool ReadVarValue(trimja::EvalStringBuilder* value, std::string* err) {
     return ReadEvalString(value, false, err);
   }
 
@@ -115,7 +115,7 @@ struct Lexer {
   void EatWhitespace();
 
   /// Read a $-escaped string.
-  bool ReadEvalString(trimja::EvalString* eval, bool path, std::string* err);
+  bool ReadEvalString(trimja::EvalStringBuilder* eval, bool path, std::string* err);
 
   std::filesystem::path filename_;
   std::string_view input_;


### PR DESCRIPTION
Not a particularly important change, but we can reduce the size of `Rule`, which has a `std::vector` containing `EvalString` elements, by 8 bytes if we remove the `m_lastTextSegmentLength` element.

This element is only used when building up our `EvalString` elements, so we can move it out to a separate `EvalStringBuilder` type and make `EvalString` immutable from its public API.