### PR TITLE
Simplify `ninja_clock`

### DIFF
--- a/src/ninja_clock.cpp
+++ b/src/ninja_clock.cpp
@@ -43,21 +43,8 @@ const std::uint64_t offset = 0;
 
 }  // namespace
 
-trimja::ninja_clock::time_point ninja_clock::from_file_clock(
-    std::chrono::file_clock::time_point t) {
-  return trimja::ninja_clock::time_point(
-      trimja::ninja_clock::duration(t.time_since_epoch().count() - offset));
-}
-
-std::chrono::file_clock::time_point ninja_clock::to_file_clock(
-    trimja::ninja_clock::time_point t) {
-  return std::chrono::file_clock::time_point(
-      std::chrono::file_clock::duration(t.time_since_epoch().count() + offset));
-}
-
 }  // namespace trimja
 
-#if defined(__cpp_lib_chrono) && __cpp_lib_chrono >= 202002L
 namespace std {
 namespace chrono {
 
@@ -77,4 +64,3 @@ clock_time_conversion<file_clock, trimja::ninja_clock>::operator()(
 
 }  // namespace chrono
 }  // namespace std
-#endif

--- a/src/ninja_clock.h
+++ b/src/ninja_clock.h
@@ -40,29 +40,10 @@ struct ninja_clock {
   using duration = std::chrono::duration<rep, period>;
   using time_point = std::chrono::time_point<ninja_clock>;
   static const bool is_steady = false;
-
-  /**
-   * @brief Converts a file_clock::time_point to a ninja_clock::time_point.
-   *
-   * @param t The file_clock::time_point to convert.
-   * @return The corresponding ninja_clock::time_point.
-   */
-  static trimja::ninja_clock::time_point from_file_clock(
-      std::chrono::file_clock::time_point t);
-
-  /**
-   * @brief Converts a ninja_clock::time_point to a file_clock::time_point.
-   *
-   * @param t The ninja_clock::time_point to convert.
-   * @return The corresponding file_clock::time_point.
-   */
-  static std::chrono::file_clock::time_point to_file_clock(
-      trimja::ninja_clock::time_point t);
 };
 
 }  // namespace trimja
 
-#if defined(__cpp_lib_chrono) && __cpp_lib_chrono >= 202002L
 // Supported only with later versions of C++20
 namespace std {
 namespace chrono {
@@ -101,5 +82,5 @@ struct clock_time_conversion<file_clock, trimja::ninja_clock> {
 
 }  // namespace chrono
 }  // namespace std
-#endif
+
 #endif  // TRIMJA_NINJA_CLOCK


### PR DESCRIPTION
Remove the unused `static` methods and unconditionally include the `clock_time_conversion`.