### PR TITLE
Change `OutputText` to use a `std::pmr::list`

### DIFF
--- a/src/all.natvis
+++ b/src/all.natvis
@@ -68,14 +68,6 @@
     </Expand>
   </Type>
 
-  <Type Name="trimja::detail::IndexIntoDebug&lt;trimja::detail::OutputText,*,*&gt;">
-    <DisplayString>{{ text = {m_container->parts[m_index]}, type = {m_container->partsType[m_index]} }}</DisplayString>
-    <Expand>
-      <Item Name="text">m_container->parts[m_index]</Item>
-      <Item Name="type">m_container->partsType[m_index]</Item>
-    </Expand>
-  </Type>
-
   <Type Name="trimja::detail::IndexIntoDebug&lt;trimja::detail::BuildContext,trimja::detail::BuildContext::BuildCommandTag,*&gt;">
     <DisplayString>{{ out = {m_container->commands[m_index].outStr} }}</DisplayString>
     <Expand>


### PR DESCRIPTION
To prepare for more complex changes in `trimutil.cpp`, we change the underlying data structure for `OutputText` to a `std::pmr::list`.  This will give us O(1) insertion when we need to make changes to the output. Previously we could only overwrite pieces of the `std::vector`, so we had to make sure that when we broke up the initial input, we had enough space for any future changes.

By using a monotonic allocator, we should avoid a lot of the performance issues going from a `std::vector` to `std::list` as most of the nodes will be still be contiguous in memory.