### PR TITLE
Disambiguate clang versions for trimja

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
       with:
         version: 1.3.1
         path: output/build.ninja
-        build-configuration: ${{ matrix.build_type }}
+        build-configuration: ${{ matrix.environment.name }} ${{ matrix.build_type }}
         target-default: true
         targets: |
           run_test_with_dependencies


### PR DESCRIPTION
Clang and clang-latest are sharing the same trimja cache because we only passed the platform to `build-configuration`.