### PR TITLE
Split release from build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,8 @@ on:
       - "v*.*.*"
   pull_request:
     branches: ["main"]
+permissions:
+  contents: read
 jobs:
   build:
     strategy:
@@ -28,10 +30,10 @@ jobs:
         build_type: [Debug, Release]
     name: ${{ matrix.environment.name }} (${{ matrix.build_type }})
     runs-on: ${{ matrix.environment.image }}
-    permissions:
-      contents: write
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     - name: Configure CMake
       run: >
         cmake -B output
@@ -55,20 +57,50 @@ jobs:
       run: cmake --build output --config ${{ matrix.build_type }}
     - name: Test
       run: cmake --build output --target run_test_with_dependencies --config ${{ matrix.build_type }}
+    - name: Check if this is a packaged release build
+      id: release
+      shell: bash
+      run: echo "package=${{ startsWith(github.ref, 'refs/tags/') && matrix.build_type == 'Release' && matrix.environment.package }}" >> "$GITHUB_OUTPUT"
     - name: Install NSIS
       # windows-latest no longer ships NSIS, but we need it to build the .exe installer
-      if: startsWith(github.ref, 'refs/tags/') && matrix.build_type == 'Release' && matrix.environment.package && matrix.environment.name == 'Windows'
+      if: steps.release.outputs.package == 'true' && matrix.environment.name == 'Windows'
       run: choco install nsis -y --no-progress
     - name: Install
-      if: startsWith(github.ref, 'refs/tags/') && matrix.build_type == 'Release' && matrix.environment.package
+      if: steps.release.outputs.package == 'true'
       run: cmake --build output --config ${{ matrix.build_type }} --target package
+    - name: Upload package
+      if: steps.release.outputs.package == 'true'
+      uses: actions/upload-artifact@v7
+      with:
+        name: package-${{ matrix.environment.name }}
+        if-no-files-found: ignore
+        path: |
+          output/trimja-*-Linux.tar.gz
+          output/trimja-*-Darwin.tar.gz
+          output/trimja-*-win64.exe
+          output/trimja-*.zip
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') && needs.build.result == 'success'
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+    - name: Download packages
+      uses: actions/download-artifact@v8
+      with:
+        pattern: package-*
+        path: output
+        merge-multiple: true
     - name: Generate Changelog
       run: git show -s --format='%b' > output/CHANGELOG.txt
-      if: startsWith(github.ref, 'refs/tags/') && matrix.build_type == 'Release' && matrix.environment.package
     - name: Release
       uses: softprops/action-gh-release@v3
-      if: startsWith(github.ref, 'refs/tags/') && matrix.build_type == 'Release' && matrix.environment.package
       with:
+        fail_on_unmatched_files: true
         body_path: output/CHANGELOG.txt
         files: |
           output/trimja-*-Linux.tar.gz
@@ -79,6 +111,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     - name: Run clang-format
       run: >
         git ls-files -z


### PR DESCRIPTION
In order to scope write permissions that we only need at release time, we split the release job from the build job.

A nice side-effect is that the release will only occur once all the build artifacts are ready.  We try to fail in `action-gh-release` if we cannot find all of the required files as well now.