### PR TITLE
Separate build and release CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,8 +2,6 @@ name: CI
 on:
   push:
     branches: ["main"]
-    tags:
-      - "v*.*.*"
   pull_request:
     branches: ["main"]
 permissions:
@@ -20,12 +18,12 @@ jobs:
           # with all GitHub Action runners. For Linux (GCC) with choose the
           # oldest version that supports everything we have on the other
           # platforms to maximise compiler compatibility.
-          {name: Linux (clang), image: ubuntu-22.04, cpp: clang++-13, c: clang-13, generator: Ninja, clang-tidy: true, package: true},
-          {name: Linux (gcc), image: ubuntu-22.04, cpp: g++-12, c: gcc-12, generator: Ninja, package: false},
-          {name: MacOS, image: macos-14, cpp: clang++, c: clang, generator: Ninja, package: true},
-          {name: Windows, image: windows-latest, cpp: cl, c: cl, package: true},
+          {name: Linux (clang), image: ubuntu-22.04, cpp: clang++-13, c: clang-13, generator: Ninja, clang-tidy: true},
+          {name: Linux (gcc), image: ubuntu-22.04, cpp: g++-12, c: gcc-12, generator: Ninja},
+          {name: MacOS, image: macos-14, cpp: clang++, c: clang, generator: Ninja},
+          {name: Windows, image: windows-latest, cpp: cl, c: cl},
           # Compile on the latest clang to get the latest clang-tidy
-          {name: Linux (clang-latest), image: ubuntu-latest, cpp: clang++, c: clang, generator: Ninja, clang-tidy: true, package: false},
+          {name: Linux (clang-latest), image: ubuntu-latest, cpp: clang++, c: clang, generator: Ninja, clang-tidy: true},
         ]
         build_type: [Debug, Release]
     name: ${{ matrix.environment.name }} (${{ matrix.build_type }})
@@ -34,6 +32,9 @@ jobs:
     - uses: actions/checkout@v7
       with:
         persist-credentials: false
+    # NOTE: the Configure CMake/Build/Test steps below are duplicated in
+    # release.yaml (for the packaging-relevant environments, Release only).
+    # Keep the two in sync when editing either one.
     - name: Configure CMake
       run: >
         cmake -B output
@@ -43,8 +44,8 @@ jobs:
         ${{ matrix.environment.generator != '' && format('-G {0}', matrix.environment.generator) || ''}}
         ${{ matrix.environment.clang-tidy && '-DENABLE_CLANG_TIDY=ON' || ''}}
     - uses: elliotgoodrich/trimja-action@v2
-      # Skip Windows (which doesn't yet use Ninja) and releases
-      if: matrix.environment.name != 'Windows' && !startsWith(github.ref, 'refs/tags/')
+      # Skip Windows (which doesn't yet use Ninja)
+      if: matrix.environment.name != 'Windows'
       with:
         version: 1.3.1
         path: output/build.ninja
@@ -57,56 +58,6 @@ jobs:
       run: cmake --build output --config ${{ matrix.build_type }}
     - name: Test
       run: cmake --build output --target run_test_with_dependencies --config ${{ matrix.build_type }}
-    - name: Check if this is a packaged release build
-      id: release
-      shell: bash
-      run: echo "package=${{ startsWith(github.ref, 'refs/tags/') && matrix.build_type == 'Release' && matrix.environment.package }}" >> "$GITHUB_OUTPUT"
-    - name: Install NSIS
-      # windows-latest no longer ships NSIS, but we need it to build the .exe installer
-      if: steps.release.outputs.package == 'true' && matrix.environment.name == 'Windows'
-      run: choco install nsis -y --no-progress
-    - name: Install
-      if: steps.release.outputs.package == 'true'
-      run: cmake --build output --config ${{ matrix.build_type }} --target package
-    - name: Upload package
-      if: steps.release.outputs.package == 'true'
-      uses: actions/upload-artifact@v7
-      with:
-        name: package-${{ matrix.environment.name }}
-        if-no-files-found: ignore
-        path: |
-          output/trimja-*-Linux.tar.gz
-          output/trimja-*-Darwin.tar.gz
-          output/trimja-*-win64.exe
-          output/trimja-*.zip
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && needs.build.result == 'success'
-    permissions:
-      contents: write
-    steps:
-    - uses: actions/checkout@v7
-      with:
-        persist-credentials: false
-    - name: Download packages
-      uses: actions/download-artifact@v8
-      with:
-        pattern: package-*
-        path: output
-        merge-multiple: true
-    - name: Generate Changelog
-      run: git show -s --format='%b' > output/CHANGELOG.txt
-    - name: Release
-      uses: softprops/action-gh-release@v3
-      with:
-        fail_on_unmatched_files: true
-        body_path: output/CHANGELOG.txt
-        files: |
-          output/trimja-*-Linux.tar.gz
-          output/trimja-*-Darwin.tar.gz
-          output/trimja-*-win64.exe
-          output/trimja-*.zip
   format:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,85 @@
+name: Release
+on:
+  push:
+    tags:
+      - "v*.*.*"
+permissions:
+  contents: read
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [
+          # Linux (Clang) and MacOS must use the oldest GitHub Action runner
+          # since we want to compile against the oldest libc version
+          # possible.  This means that all binaries created will be compatible
+          # with all GitHub Action runners.
+          {name: Linux (clang), image: ubuntu-22.04, cpp: clang++-13, c: clang-13, generator: Ninja, clang-tidy: true},
+          {name: MacOS, image: macos-14, cpp: clang++, c: clang, generator: Ninja},
+          {name: Windows, image: windows-latest, cpp: cl, c: cl},
+        ]
+    name: ${{ matrix.environment.name }}
+    runs-on: ${{ matrix.environment.image }}
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+    # NOTE: the Configure CMake/Build/Test steps below are duplicated in
+    # ci.yaml (for the full environment/build_type matrix, plus trimja).
+    # Keep the two in sync when editing either one.
+    - name: Configure CMake
+      run: >
+        cmake -B output
+        -DCMAKE_CXX_COMPILER=${{ matrix.environment.cpp }}
+        -DCMAKE_C_COMPILER=${{ matrix.environment.c }}
+        ${{ matrix.environment.name == 'Windows' && '-DCMAKE_CONFIGURATION_TYPES=Release' || '-DCMAKE_BUILD_TYPE=Release' }}
+        ${{ matrix.environment.generator != '' && format('-G {0}', matrix.environment.generator) || ''}}
+        ${{ matrix.environment.clang-tidy && '-DENABLE_CLANG_TIDY=ON' || ''}}
+    - name: Build
+      run: cmake --build output --config Release
+    - name: Test
+      run: cmake --build output --target run_test_with_dependencies --config Release
+    - name: Install NSIS
+      # windows-latest no longer ships NSIS, but we need it to build the .exe installer
+      if: matrix.environment.name == 'Windows'
+      run: choco install nsis -y --no-progress
+    - name: Install
+      run: cmake --build output --config Release --target package
+    - name: Upload package
+      uses: actions/upload-artifact@v7
+      with:
+        name: package-${{ matrix.environment.name }}
+        if-no-files-found: ignore
+        path: |
+          output/trimja-*-Linux.tar.gz
+          output/trimja-*-Darwin.tar.gz
+          output/trimja-*-win64.exe
+          output/trimja-*.zip
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
+    - name: Download packages
+      uses: actions/download-artifact@v8
+      with:
+        pattern: package-*
+        path: output
+        merge-multiple: true
+    - name: Generate Changelog
+      run: git show -s --format='%b' > output/CHANGELOG.txt
+    - name: Release
+      uses: softprops/action-gh-release@v3
+      with:
+        fail_on_unmatched_files: true
+        body_path: output/CHANGELOG.txt
+        files: |
+          output/trimja-*-Linux.tar.gz
+          output/trimja-*-Darwin.tar.gz
+          output/trimja-*-win64.exe
+          output/trimja-*.zip


### PR DESCRIPTION
After a previous commit to increase security, we now had a separate release job that was skipped on PRs. I don't like the look of checks being skipped on PRs because it gives the impression something is disabled.

This change splits up build and release so that build runs on PRs and release runs when we tag a commit.